### PR TITLE
Fix CI-build of interpreter module when deploying from main branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,11 @@
 name: Deploy Module to GitHub Packages
 
-on: push
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "*"
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR addresses multiple issues when trying to deploy the module from the main branch. The workflow has previously been successfully tested on a feature branch only.

- Setting the version of the package no longer fails when the version is set to the implicit default value (0.0.0)
- The workflow is no longer run twice when the latest commit is tagged for release