### PR TITLE
Only trigger deployment when a tag is created on main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - "*"
     branches:
-      - "fix-deploy-only-on-tag-creation"
+      - "main"
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR tries to address an issue with the release pipeline. The pipeline is currently triggered on every commit on main, not just on tags on main. This behavior is not desired. It remains to be seen whether the change in the trigger works out for all common situations, simply by testing this on main.