### PR TITLE
Only trigger deployment when a tag is created on main (again)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy Module to GitHub Packages
 
 on:
-  create:
+  push:
     tags:
       - "v*"
 


### PR DESCRIPTION
This PR (once again) tries to resolve the trigger of the GitHub action that deploys the package to GitHub packages.

Fixing the trigger has previously been attempted in #19. However, that fix falsely triggered the deployment workflow not only when tags were created on main, but also when branches were created.

This PR attempts to fix this issue by using a condition on the job instead of editing just the trigger of the entire action.