### PR TITLE
Reslove parser ambiguity

### DIFF
--- a/src/features/assignment.ts
+++ b/src/features/assignment.ts
@@ -1,4 +1,4 @@
-import { apply, kright, opt, seq, str, tok, Token } from "typescript-parsec";
+import { apply, kright, opt_sc, seq, str, tok, Token } from "typescript-parsec";
 import { InterpretableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
@@ -134,7 +134,7 @@ const typeAnnotation = kright(
 export const assignment = apply(
   seq(
     tok(TokenKind.ident),
-    surround_with_breaking_whitespace(opt(typeAnnotation)),
+    surround_with_breaking_whitespace(opt_sc(typeAnnotation)),
     ends_with_breaking_whitespace(str("=")),
     expression,
   ),

--- a/src/features/condition.ts
+++ b/src/features/condition.ts
@@ -1,4 +1,4 @@
-import { apply, kmid, kright, opt, seq, str, Token } from "typescript-parsec";
+import { apply, kmid, kright, opt_sc, seq, str, Token } from "typescript-parsec";
 import { InterpretableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
@@ -111,7 +111,7 @@ condition.setPattern(
         statements,
       ),
       surround_with_breaking_whitespace(str("}")),
-      opt(elseBranch),
+      opt_sc(elseBranch),
     ),
     ([ifKeyword, condition, ifStatements, firstClosingBrace, elseBranch]) => {
       const [falseStatements, elseClosingBrace] = elseBranch ?? [];

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -4,12 +4,11 @@ import {
   kmid,
   kright,
   list_sc,
-  opt,
   opt_sc,
   seq,
   str,
   tok,
-  Token,
+  Token
 } from "typescript-parsec";
 import { AstNode, EvaluableAstNode, InterpretableAstNode } from "../ast.ts";
 import {
@@ -428,7 +427,7 @@ functionDefinition.setPattern(apply(
 returnStatement.setPattern(apply(
   kouter(
     str<TokenKind>("return"),
-    opt(tok(TokenKind.breakingWhitespace)),
+    opt_sc(tok(TokenKind.breakingWhitespace)),
     opt_sc(expression),
   ),
   ([keyword, expression]) =>

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -4,7 +4,7 @@ import {
   kleft,
   kright,
   list_sc,
-  opt,
+  opt_sc,
   seq,
   str,
   tok,
@@ -109,7 +109,7 @@ const fields = kleft(
     field,
     fieldSeparator,
   ),
-  opt(str(",")),
+  opt_sc(str(",")),
 );
 
 export const structureDefinition = apply(
@@ -119,7 +119,7 @@ export const structureDefinition = apply(
     seq(
       kright(
         str("{"),
-        opt(surround_with_breaking_whitespace(fields)),
+        opt_sc(surround_with_breaking_whitespace(fields)),
       ),
       str("}"),
     ),

--- a/src/util/parser.ts
+++ b/src/util/parser.ts
@@ -3,11 +3,11 @@ import {
   kleft,
   kmid,
   kright,
-  opt,
+  opt_sc,
   Parser,
   rep_sc,
   seq,
-  tok,
+  tok
 } from "typescript-parsec";
 import { TokenKind } from "../lexer.ts";
 
@@ -119,7 +119,7 @@ export function starts_with_breaking_whitespace<T>(
   p: Parser<TokenKind, T>,
 ): Parser<TokenKind, T> {
   return kright(
-    opt(tok(TokenKind.breakingWhitespace)),
+    opt_sc(tok(TokenKind.breakingWhitespace)),
     p,
   );
 }
@@ -132,7 +132,7 @@ export function ends_with_breaking_whitespace<T>(
 ): Parser<TokenKind, T> {
   return kleft(
     p,
-    opt(tok(TokenKind.breakingWhitespace)),
+    opt_sc(tok(TokenKind.breakingWhitespace)),
   );
 }
 
@@ -143,8 +143,8 @@ export function surround_with_breaking_whitespace<T>(
   p: Parser<TokenKind, T>,
 ): Parser<TokenKind, T> {
   return kmid(
-    opt(tok(TokenKind.breakingWhitespace)),
+    opt_sc(tok(TokenKind.breakingWhitespace)),
     p,
-    opt(tok(TokenKind.breakingWhitespace)),
+    opt_sc(tok(TokenKind.breakingWhitespace)),
   );
 }


### PR DESCRIPTION
In some cases, the parser would yield more than one way to parse the input (source code). This ambiguity is the result of using parsers which are supposed to do exaclty that. To address this issue, greedy parsers (e.g. `opt_sc`) are used instead of their ambiguous counterparts (e.g. `opt`).