### PR TITLE
Spell all included types in capital letters

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -7,7 +7,7 @@ export interface SymbolType {
   isPrimitive(kind: PrimitiveSymbolTypeKind): boolean;
 }
 
-type PrimitiveSymbolTypeKind = "number" | "boolean" | "string";
+type PrimitiveSymbolTypeKind = "Number" | "Boolean" | "String";
 
 export class PrimitiveSymbolType implements SymbolType {
   constructor(private kind: PrimitiveSymbolTypeKind) {}
@@ -178,9 +178,9 @@ export class TypeTable {
 }
 
 export const typeTable = new TypeTable();
-typeTable.setType("number", new PrimitiveSymbolType("number"));
-typeTable.setType("boolean", new PrimitiveSymbolType("boolean"));
-typeTable.setType("string", new PrimitiveSymbolType("string"));
+typeTable.setType("Number", new PrimitiveSymbolType("Number"));
+typeTable.setType("Boolean", new PrimitiveSymbolType("Boolean"));
+typeTable.setType("String", new PrimitiveSymbolType("String"));
 
 /* ~~~ TEMPORARY ~~~ */
 


### PR DESCRIPTION
This PR introduces a change in which all types that ship with the language are spelled with capital letters. Primitive types have been spelled in lowercase letters previously.