### PR TITLE
Fix internal references to primitive types

### DIFF
--- a/src/features/boolean_expression.ts
+++ b/src/features/boolean_expression.ts
@@ -44,7 +44,7 @@ class BooleanLiteralAstNode implements BooleanExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("boolean");
+    return new PrimitiveSymbolType("Boolean");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -71,7 +71,7 @@ class BooleanNegationAstNode implements BooleanExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("boolean");
+    return new PrimitiveSymbolType("Boolean");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -114,7 +114,7 @@ class BinaryBooleanExpressionAstNode implements BooleanExpressionAstNode {
     }
     if (
       [">", ">=", "<", "<="].includes(operator) &&
-      (!leftType.isPrimitive("number") || !rightType.isPrimitive("number"))
+      (!leftType.isPrimitive("Number") || !rightType.isPrimitive("Number"))
     ) {
       findings.errors.push(AnalysisError({
         message:
@@ -125,7 +125,7 @@ class BinaryBooleanExpressionAstNode implements BooleanExpressionAstNode {
     }
     if (
       ["&&", "||", "^"].includes(operator) &&
-      (!leftType.isPrimitive("boolean") || !rightType.isPrimitive("boolean"))
+      (!leftType.isPrimitive("Boolean") || !rightType.isPrimitive("Boolean"))
     ) {
       findings.errors.push(AnalysisError({
         message:
@@ -180,7 +180,7 @@ class BinaryBooleanExpressionAstNode implements BooleanExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("boolean");
+    return new PrimitiveSymbolType("Boolean");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/condition.ts
+++ b/src/features/condition.ts
@@ -50,7 +50,7 @@ export class ConditionAstNode implements InterpretableAstNode {
       return findings;
     }
     const conditionType = this.condition.resolveType();
-    if (!conditionType.isPrimitive("boolean")) {
+    if (!conditionType.isPrimitive("Boolean")) {
       findings.errors.push(AnalysisError({
         message:
           "The expression inside of the if statement needs to evaluate to a boolean value.",

--- a/src/features/numeric_expression.ts
+++ b/src/features/numeric_expression.ts
@@ -42,7 +42,7 @@ class NumericLiteralAstNode implements NumericExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("number");
+    return new PrimitiveSymbolType("Number");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -82,7 +82,7 @@ class UnaryNumericExpressionAstNode implements NumericExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("number");
+    return new PrimitiveSymbolType("Number");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -157,7 +157,7 @@ class BinaryNumericExpressionAstNode implements NumericExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("number");
+    return new PrimitiveSymbolType("Number");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -177,7 +177,7 @@ class AmbiguouslyTypedExpressionAstNode implements NumericExpressionAstNode {
 
   analyze(): AnalysisFindings {
     const analysisResult = this.child.analyze();
-    if (!this.child.resolveType().isPrimitive("number")) {
+    if (!this.child.resolveType().isPrimitive("Number")) {
       analysisResult.errors.push(AnalysisError({
         message:
           "You tried to use a numeric operation on something that is not a number.",
@@ -195,7 +195,7 @@ class AmbiguouslyTypedExpressionAstNode implements NumericExpressionAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("number");
+    return new PrimitiveSymbolType("Number");
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/string.ts
+++ b/src/features/string.ts
@@ -25,7 +25,7 @@ class StringAstNode implements EvaluableAstNode {
   }
 
   resolveType(): SymbolType {
-    return new PrimitiveSymbolType("string");
+    return new PrimitiveSymbolType("String");
   }
 
   analyze(): AnalysisFindings {

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -41,7 +41,7 @@ export interface SymbolValue<T = unknown> {
 }
 
 export class BooleanSymbolValue implements SymbolValue<boolean> {
-  valueType: SymbolType = new PrimitiveSymbolType("boolean");
+  valueType: SymbolType = new PrimitiveSymbolType("Boolean");
 
   constructor(public value: boolean) {}
 
@@ -55,7 +55,7 @@ export class BooleanSymbolValue implements SymbolValue<boolean> {
 }
 
 export class NumericSymbolValue implements SymbolValue<number> {
-  valueType: SymbolType = new PrimitiveSymbolType("number");
+  valueType: SymbolType = new PrimitiveSymbolType("Number");
 
   constructor(public value: number) {}
 
@@ -69,7 +69,7 @@ export class NumericSymbolValue implements SymbolValue<number> {
 }
 
 export class StringSymbolValue implements SymbolValue<string> {
-  valueType: SymbolType = new PrimitiveSymbolType("string");
+  valueType: SymbolType = new PrimitiveSymbolType("String");
 
   constructor(public value: string) {}
 


### PR DESCRIPTION
All builtin types in the language are now spelt with capital letters. However, not all references in the implementation itself followed that convention. This PR fixed that.