### PR TITLE
Fix NPM release pipeline failing due to metadata file transfer

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: package-json
-          path: package.json
+          path: .
 
       # Create a temporary `.npmrc` file with credentials from the CI before publishing.
       - name: Publish module


### PR DESCRIPTION
The CI pipeline responsible for publishing the package to NPM/GH packages separates the build and publish process. between those two jobs, a metadata file needs to be transfered. In the current state, the transfer of the metadata file fails. This PR tries to address this issue.