### PR TITLE
Fix further release pipeline errors

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -123,6 +123,7 @@ jobs:
           echo "@${{ github.repository_owner }}:registry=https://npm.pkg.github.com" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
           npm pkg set "publishConfig.registry"="https://npm.pkg.github.com/"
+          npm pkg set "name"="@leonpuchinger/rouge"
           npm publish
 
   publish-npm:


### PR DESCRIPTION
This PR addresses further issues with the release pipeline regarding NPM/GH packages. Specifically, NPM packages need to explicitly be published as "public". The package that is published to GH packages is also published under a different scope than the package on NPM as that would require creating a dedicated GH organization.