### PR TITLE
Allow importing important types from the library

### DIFF
--- a/src/finding.ts
+++ b/src/finding.ts
@@ -5,7 +5,7 @@ import { createSnippet } from "./util/snippet.ts";
 import { toMultiline } from "./util/string.ts";
 import { Attributes } from "./util/type.ts";
 
-type AnalysisFindingKind = "error" | "warning";
+export type AnalysisFindingKind = "error" | "warning";
 
 /**
  * Represents an issue with the users source code input.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,13 @@ import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
 import { updateEnvironment } from "./util/environment.ts";
 
+export type {
+  AnalysisFinding,
+  AnalysisFindingKind,
+  AnalysisFindings,
+} from "./finding.ts";
+export type { Option, Result } from "./util/monad/index.ts";
+
 export function run(source: string): AnalysisFindings {
   updateEnvironment({ source: source });
   const tokenStream = tokenize(source);


### PR DESCRIPTION
Currently, the library includes types that are used in combination with the functions that are offered by the library. However, currently it is not possible to explicitly import the types from the library to use them, for instance, in a type annotation. This PR explicitly exports a selection of important types from within the library so they can now be imported.