### PR TITLE
inform about the projects WIP status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,11 @@
 
 Teach your grandmother how to program.
 
+## State of development
+
+Rouge is in active development (WIP) with many core features still missing.
+Until its initial 1.0 release, breaking changes may occur without warning.
+
 ## Build
 
 The language can be compiled into a single ES-module.


### PR DESCRIPTION
This PR only adds a simple notice that the project is still a work in progress (WIP) before the repository is opened to the public.