### PR TITLE
Introduce a loader for the standard library

### DIFF
--- a/src/features/assignment.ts
+++ b/src/features/assignment.ts
@@ -55,6 +55,7 @@ export class AssignmentAstNode implements InterpretableAstNode {
       const expressionType = this.child.resolveType();
       this.typeAnnotation.then((annotationName) => {
         const resolvedAnnotation = typeTable.findType(annotationName.text)
+          .map(([type, _flags]) => type)
           .unwrap();
         if (!resolvedAnnotation.typeCompatibleWith(expressionType)) {
           findings.errors.push(AnalysisError({

--- a/src/features/assignment.ts
+++ b/src/features/assignment.ts
@@ -81,7 +81,7 @@ export class AssignmentAstNode implements InterpretableAstNode {
       }
       const expressionType = this.child.resolveType();
       analysisTable.findSymbol(ident)
-        .then((existing) => {
+        .then(([existing, _flags]) => {
           if (existing.valueType.typeCompatibleWith(expressionType)) {
             return;
           }

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -73,7 +73,7 @@ class ParameterAstNode implements Partial<EvaluableAstNode> {
   analyze(): AnalysisFindings {
     const findings = AnalysisFindings.empty();
     const existingSymbol = analysisTable.findSymbol(this.name.text);
-    if (existingSymbol.kind === "some") {
+    if (existingSymbol.hasValue()) {
       findings.errors.push(AnalysisError({
         message:
           "Function parameter names have to be unique. Parameters can not share names with other variables.",

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -83,7 +83,7 @@ class ParameterAstNode implements Partial<EvaluableAstNode> {
         endHighlight: None(),
       }));
     }
-    if (typeTable.findType(this.type.text).kind === "none") {
+    if (!typeTable.findType(this.type.text).hasValue()) {
       findings.errors.push(AnalysisError({
         message: `The type called "${this.type.text}" could not be found.`,
         beginHighlight: DummyAstNode.fromToken(this.type),
@@ -94,7 +94,8 @@ class ParameterAstNode implements Partial<EvaluableAstNode> {
   }
 
   resolveType(): SymbolType {
-    const parameterType = typeTable.findType(this.type.text);
+    const parameterType = typeTable.findType(this.type.text)
+      .map(([type, _flags]) => type);
     return parameterType.unwrapOrThrow(UnresolvableSymbolTypeError());
   }
 

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -218,7 +218,7 @@ export class InvocationAstNode implements EvaluableAstNode {
       );
     const calledSymbol = analysisTable.findSymbol(this.name.text);
     const [isFunction, symbolExists] = calledSymbol
-      .map((symbol) => [symbol.valueType.isFunction(), true])
+      .map(([symbol, _flags]) => [symbol.valueType.isFunction(), true])
       .unwrapOr([false, false]);
     const calledType = typeTable.findType(this.name.text);
     const isType = calledType.hasValue();
@@ -248,7 +248,7 @@ export class InvocationAstNode implements EvaluableAstNode {
         findings,
         this.analyzeFunctionInvocation(
           calledSymbol
-            .map((symbol) => symbol.valueType)
+            .map(([symbol, _flags]) => symbol.valueType)
             .unwrap() as FunctionSymbolType,
         ),
       );
@@ -311,8 +311,9 @@ export class InvocationAstNode implements EvaluableAstNode {
   evaluate(): SymbolValue<unknown> {
     const calledSymbol = runtimeTable.findSymbol(this.name.text);
     if (calledSymbol.hasValue()) {
+      const [symbol, _flags] = calledSymbol.unwrap();
       return this.evaluateFunction(
-        calledSymbol.unwrap() as RuntimeSymbol<FunctionSymbolValue>,
+        symbol as RuntimeSymbol<FunctionSymbolValue>,
       );
     }
     // It can safely be assumed that the invocation is of a type
@@ -328,7 +329,7 @@ export class InvocationAstNode implements EvaluableAstNode {
   resolveType(): SymbolType {
     return analysisTable
       .findSymbol(this.name.text)
-      .map((symbol) => {
+      .map(([symbol, _flags]) => {
         const functionType = (symbol.valueType as FunctionSymbolType).fork();
         // bind placeholdes to the supplied types
         for (

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -121,6 +121,7 @@ export class InvocationAstNode implements EvaluableAstNode {
         Array.from(functionType.placeholders.values()),
         this.placeholders.map((placeholder) =>
           typeTable.findType(placeholder.text)
+            .map(([type, _flags]) => type)
         ),
       )
     ) {
@@ -184,6 +185,7 @@ export class InvocationAstNode implements EvaluableAstNode {
         Array.from(structureType.placeholders.values()),
         this.placeholders.map((placeholder) =>
           typeTable.findType(placeholder.text)
+            .map(([type, _flags]) => type)
         ),
       )
     ) {
@@ -220,7 +222,8 @@ export class InvocationAstNode implements EvaluableAstNode {
     const [isFunction, symbolExists] = calledSymbol
       .map(([symbol, _flags]) => [symbol.valueType.isFunction(), true])
       .unwrapOr([false, false]);
-    const calledType = typeTable.findType(this.name.text);
+    const calledType = typeTable.findType(this.name.text)
+      .map(([type, _flags]) => type);
     const isType = calledType.hasValue();
     if (symbolExists && isType) {
       throw new InternalError(
@@ -320,7 +323,8 @@ export class InvocationAstNode implements EvaluableAstNode {
     // since no function with the name was found in the symbol table
     // and static analysis guarantees that either a function or type
     // with the name exists.
-    const calledStructure = typeTable.findType(this.name.text);
+    const calledStructure = typeTable.findType(this.name.text)
+      .map(([type, _flags]) => type);
     return this.evaluateStructure(
       calledStructure.unwrap() as CompositeSymbolType,
     );
@@ -337,6 +341,7 @@ export class InvocationAstNode implements EvaluableAstNode {
             Array.from(functionType.placeholders.values()),
             this.placeholders.map((placeholder) =>
               typeTable.findType(placeholder.text)
+                .map(([type, _flags]) => type)
             ),
           )
         ) {
@@ -345,7 +350,10 @@ export class InvocationAstNode implements EvaluableAstNode {
         return functionType.returnType;
       })
       .unwrapOrElse(
-        typeTable.findType(this.name.text).unwrap,
+        typeTable
+          .findType(this.name.text)
+          .map(([type, _flags]) => type)
+          .unwrap,
       );
   }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -62,14 +62,24 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
   analyze(): AnalysisFindings {
     let findings = AnalysisFindings.empty();
     typeTable.findType(this.name.text)
-      .then(() => {
-        findings.errors.push(AnalysisError({
-          message: "Names for structures have to be unique.",
-          beginHighlight: DummyAstNode.fromToken(this.name),
-          endHighlight: None(),
-          messageHighlight:
-            `A structure by the name "${this.name.text}" already exists.`,
-        }));
+      .then(([_type, flags]) => {
+        if (flags.readonly) {
+          findings.errors.push(AnalysisError({
+            message:
+              "This name cannot be used because it is part of the language.",
+            beginHighlight: DummyAstNode.fromToken(this.name),
+            endHighlight: None(),
+            messageHighlight: "",
+          }));
+        } else {
+          findings.errors.push(AnalysisError({
+            message: "Names for structures have to be unique.",
+            beginHighlight: DummyAstNode.fromToken(this.name),
+            endHighlight: None(),
+            messageHighlight:
+              `A structure by the name "${this.name.text}" already exists.`,
+          }));
+        }
       });
     let unproblematicPlaceholders: string[] = [];
     for (const placeholder of this.placeholders) {

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -20,7 +20,7 @@ export class SymbolExpressionAstNode implements EvaluableAstNode {
     const ident = this.identifierToken.text;
     return runtimeTable
       .findSymbol(ident)
-      .map((symbol) => symbol.value)
+      .map(([symbol, _flags]) => symbol.value)
       .unwrapOrThrow(
         new InternalError(
           `Unable to resolve symbol ${ident} in the symbol table.`,
@@ -49,7 +49,7 @@ export class SymbolExpressionAstNode implements EvaluableAstNode {
   resolveType(): SymbolType {
     return analysisTable
       .findSymbol(this.identifierToken.text)
-      .map((symbol) => symbol.valueType)
+      .map(([symbol, _flags]) => symbol.valueType)
       .unwrapOrThrow(
         new InternalError(
           "Unable to resolve a symbol in the symbol table.",

--- a/src/features/type_literal.ts
+++ b/src/features/type_literal.ts
@@ -94,7 +94,8 @@ export class CompositeTypeLiteralAstNode implements Partial<EvaluableAstNode> {
 
   analyze(): AnalysisFindings {
     let findings = AnalysisFindings.empty();
-    const type = typeTable.findType(this.name.text);
+    const type = typeTable.findType(this.name.text)
+      .map(([type, _flags]) => type);
     if (!type.hasValue()) {
       findings.errors.push(AnalysisError({
         beginHighlight: DummyAstNode.fromToken(this.name),
@@ -125,6 +126,7 @@ export class CompositeTypeLiteralAstNode implements Partial<EvaluableAstNode> {
       .map((placeholder) => placeholder.resolveType());
     let resolvedType = typeTable
       .findType(this.name.text)
+      .map(([type, _flags]) => type)
       .unwrap() as CompositeSymbolType;
     if (placeholderTypes.length !== 0) {
       /* Only fork the type in case it can be modified by parameterizing it with placeholders

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,8 @@ export function run(source: string): AnalysisFindings {
 }
 
 export function analyze(source: string): AnalysisFindings {
+  const stdlibAst = parseStdlib();
+  analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });
   const tokenStream = tokenize(source);
   const ast = parse(tokenStream);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { AnalysisFindings } from "./finding.ts";
 import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
+import { analyzeStdlib, parseStdlib } from "./stdlib.ts";
 import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
 
@@ -12,6 +13,8 @@ export type {
 export type { Option, Result } from "./util/monad/index.ts";
 
 export function run(source: string): AnalysisFindings {
+  const stdlibAst = parseStdlib();
+  analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });
   const tokenStream = tokenize(source);
   const ast = parse(tokenStream);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ export function run(source: string): AnalysisFindings {
   const analysisFindings = ast.analyze();
   typeTable.reset();
   if (analysisFindings.errors.length == 0) {
+    stdlibAst.interpret();
     ast.interpret();
   }
   return analysisFindings;

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -1,5 +1,40 @@
+import { AST } from "./ast.ts";
+import { tokenize } from "./lexer.ts";
+import { parse } from "./parser.ts";
+import { updateEnvironment } from "./util/environment.ts";
+import { InternalError } from "./util/error.ts";
+
 const stdlib = `
     print = function(message: String) {
         // do nothing for now
     };
 `;
+
+/**
+ * Parses a separate and independent AST for the standard library.
+ */
+export function parseStdlib() {
+    updateEnvironment({ source: stdlib });
+    const tokenStream = tokenize(stdlib);
+    const ast = parse(tokenStream);
+    updateEnvironment({ source: "" });
+    return ast;
+}
+
+/**
+ * Performs static analyis on the stdlib.
+ * Should be called before the stdlib is injected into the symbol table
+ * or the static analyis of the input source is performed.
+ */
+export function analyzeStdlib(stdlibAst: AST) {
+    updateEnvironment({ source: stdlib });
+    const analysisFindings = stdlibAst.analyze();
+    // TODO: once a runtime is immplemented,
+    // clear runtime bindings from the symbol table, but
+    // leave stdlib members in the symbol table.
+    if (analysisFindings.errors.length !== 0) {
+        throw new InternalError(
+            "The standard library contains static analysis errors.",
+        );
+    }
+}

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -1,6 +1,8 @@
 import { AST } from "./ast.ts";
 import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
+import { analysisTable, runtimeTable } from "./symbol.ts";
+import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
 import { InternalError } from "./util/error.ts";
 
@@ -28,11 +30,15 @@ export function parseStdlib() {
  */
 export function analyzeStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
+    analysisTable.setGlobalFlagOverrides({ readonly: true });
+    typeTable.setGlobalFlagOverrides({ readonly: true });
     const analysisFindings = stdlibAst.analyze();
     // TODO: once a runtime is immplemented,
     // clear runtime bindings from the symbol table, but
     // leave stdlib members in the symbol table.
     updateEnvironment({ source: "" });
+    analysisTable.setGlobalFlagOverrides({ readonly: "notset" });
+    typeTable.setGlobalFlagOverrides({ readonly: "notset" });
     if (analysisFindings.errors.length !== 0) {
         throw new InternalError(
             "The standard library contains static analysis errors.",
@@ -46,6 +52,10 @@ export function analyzeStdlib(stdlibAst: AST) {
  */
 export function injectStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
+    runtimeTable.setGlobalFlagOverrides({ readonly: true});
+    typeTable.setGlobalFlagOverrides({ readonly: true });
     stdlibAst.interpret();
+    runtimeTable.setGlobalFlagOverrides({ readonly: "notset" });
+    typeTable.setGlobalFlagOverrides({ readonly: "notset" });
     updateEnvironment({ source: "" });
 }

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -32,9 +32,20 @@ export function analyzeStdlib(stdlibAst: AST) {
     // TODO: once a runtime is immplemented,
     // clear runtime bindings from the symbol table, but
     // leave stdlib members in the symbol table.
+    updateEnvironment({ source: "" });
     if (analysisFindings.errors.length !== 0) {
         throw new InternalError(
             "The standard library contains static analysis errors.",
         );
     }
+}
+
+/**
+ * Loads the standard library into the symbol and type table.
+ * It is assumed that both tables are set to the global scope.
+ */
+export function injectStdlib(stdlibAst: AST) {
+    updateEnvironment({ source: stdlib });
+    stdlibAst.interpret();
+    updateEnvironment({ source: "" });
 }

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -1,0 +1,5 @@
+const stdlib = `
+    print = function(message: String) {
+        // do nothing for now
+    };
+`;

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -7,7 +7,7 @@ import { InternalError } from "./util/error.ts";
 const stdlib = `
     print = function(message: String) {
         // do nothing for now
-    };
+    }
 `;
 
 /**

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -214,7 +214,7 @@ export class SymbolTable<S extends Symbol> {
   setSymbol(
     name: string,
     symbol: S,
-    readonly: boolean = false,
+    readonly?: boolean,
   ) {
     const currentScope = this.scopes[this.scopes.length - 1];
     const existingEntry = Some(currentScope.get(name));

--- a/src/type.ts
+++ b/src/type.ts
@@ -788,15 +788,15 @@ export class TypeTable {
   }
 
   initializeStandardLibraryTypes() {
-    this.setType("Number", new CompositeSymbolType({ id: "Number" }));
-    this.setType("Boolean", new CompositeSymbolType({ id: "Boolean" }));
-    this.setType("String", new CompositeSymbolType({ id: "String" }));
+    this.setType("Number", new CompositeSymbolType({ id: "Number" }), true);
+    this.setType("Boolean", new CompositeSymbolType({ id: "Boolean" }), true);
+    this.setType("String", new CompositeSymbolType({ id: "String" }), true);
 
     /* ~~~ TEMPORARY ~~~ */
 
     // will be replaced by stdlib implementation in the future
 
-    this.setType("Nothing", new CompositeSymbolType({ id: "Nothing" }));
+    this.setType("Nothing", new CompositeSymbolType({ id: "Nothing" }), true);
 
     /* ~~~ TEMPORARY ~~~ */
   }

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -47,6 +47,7 @@ export type WithOptionalAttributes<T> = ConvertOptionals<Attributes<T>>;
  */
 export const nothingType = typeTable
   .findType("Nothing")
+  .map(([type, _flags]) => type)
   .unwrapOrThrow(
     new InternalError(
       "The type called `Nothing` from the standard library could not be located.",


### PR DESCRIPTION
This PR introduces a loader component for the (eventual) standard library. At this point the stdlib contains only a single stub for the `print` function (for testing purposes). The stdlib also does not have access to a runtime yet.

Eventually, the stdlib is supposed to be loaded by a module system. However, the module system is not implemented yet, which is why a dedicated loader is necessary. The loader parses the stdlib as a separate AST and performs an isolated static analysis, but injects its contents in the same symbol- and type tables that are used when the user's program is executed. The tables have been modified to support setting flags on symbols and types. So far, only one flag is supported, which allows setting the contents of the stdlib to read-only mode to protect the user from accidentally overriding anything.