### PR TITLE
Add runtime bindings so the stdlib can access native functionality

### DIFF
--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -318,14 +318,14 @@ export class InvocationAstNode implements EvaluableAstNode {
       .unwrapOr(false);
     if (partOfStdlib) {
       // grant the invocation access to the runtime
-      analysisTable.ignoreRuntimeBindings = false;
+      runtimeTable.ignoreRuntimeBindings = false;
     }
     if (calledSymbol.hasValue()) {
       const [symbol, _flags] = calledSymbol.unwrap();
       const result = this.evaluateFunction(
         symbol as RuntimeSymbol<FunctionSymbolValue>,
       );
-      analysisTable.ignoreRuntimeBindings = true;
+      runtimeTable.ignoreRuntimeBindings = true;
       return result;
     }
     // It can safely be assumed that the invocation is of a type
@@ -337,7 +337,7 @@ export class InvocationAstNode implements EvaluableAstNode {
     const result = this.evaluateStructure(
       calledStructure.unwrap() as CompositeSymbolType,
     );
-    analysisTable.ignoreRuntimeBindings = true;
+    runtimeTable.ignoreRuntimeBindings = true;
     return result;
   }
 

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -246,13 +246,6 @@ export class InvocationAstNode implements EvaluableAstNode {
         endHighlight: None(),
       }));
     }
-    const partOfStdlib = calledSymbol
-      .map(([_symbol, flags]) => flags.stdlib)
-      .unwrapOr(false);
-    if (partOfStdlib) {
-      // grant the invocation access to the runtime
-      analysisTable.ignoreRuntimeBindings = false;
-    }
     if (isFunction && !findings.isErroneous()) {
       findings = AnalysisFindings.merge(
         findings,
@@ -271,7 +264,6 @@ export class InvocationAstNode implements EvaluableAstNode {
         ),
       );
     }
-    analysisTable.ignoreRuntimeBindings = true;
     return findings;
   }
 

--- a/src/features/statement.ts
+++ b/src/features/statement.ts
@@ -13,6 +13,7 @@ import { ConditionAstNode } from "./condition.ts";
 import { ReturnStatementAstNode } from "./function.ts";
 import { condition, returnStatement } from "./parser_declarations.ts";
 import { structureDefinition, StructureDefinitonAstNode } from "./structure.ts";
+import { RuntimeStatementAstNode } from "../runtime.ts";
 
 /* AST NODES */
 
@@ -21,7 +22,8 @@ export type StatementAstNode =
   | ConditionAstNode
   | ReturnStatementAstNode
   | StructureDefinitonAstNode
-  | AssignmentAstNode;
+  | AssignmentAstNode
+  | RuntimeStatementAstNode;
 
 export class StatementsAstNode implements InterpretableAstNode {
   children!: StatementAstNode[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { AnalysisFindings } from "./finding.ts";
 import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
+import { injectRuntimeBindings } from "./runtime.ts";
 import { analyzeStdlib, parseStdlib } from "./stdlib.ts";
 import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
@@ -13,6 +14,7 @@ export type {
 export type { Option, Result } from "./util/monad/index.ts";
 
 export function run(source: string): AnalysisFindings {
+  injectRuntimeBindings();
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });
@@ -28,6 +30,7 @@ export function run(source: string): AnalysisFindings {
 }
 
 export function analyze(source: string): AnalysisFindings {
+  // TODO: inject runtime bindings
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { AnalysisFindings } from "./finding.ts";
 import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
 import { injectRuntimeBindings } from "./runtime.ts";
-import { analyzeStdlib, parseStdlib } from "./stdlib.ts";
+import { analyzeStdlib, injectStdlib, parseStdlib } from "./stdlib.ts";
 import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
 
@@ -23,7 +23,7 @@ export function run(source: string): AnalysisFindings {
   const analysisFindings = ast.analyze();
   typeTable.reset();
   if (analysisFindings.errors.length == 0) {
-    stdlibAst.interpret();
+    injectStdlib(stdlibAst);
     ast.interpret();
   }
   return analysisFindings;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,40 @@
+import { StatementsAstNode } from "./features/statement.ts";
+import {
+    analysisTable,
+    FunctionSymbolValue,
+    RuntimeSymbol,
+    runtimeTable,
+    StaticSymbol,
+} from "./symbol.ts";
+import { FunctionSymbolType, SymbolType } from "./type.ts";
+import { nothingType } from "./util/type.ts";
+
+export function injectRuntimeBindings() {
+    const statements = new StatementsAstNode({
+        children: [],
+    });
+
+    const parameterTypes = new Map<string, SymbolType>();
+    const returnType = nothingType;
+    const fnType = new FunctionSymbolType({
+        parameterTypes: Array.from(parameterTypes.values()),
+        returnType: returnType,
+    });
+
+    const symbolValue = new FunctionSymbolValue({
+        value: statements,
+        parameterTypes: parameterTypes,
+        returnType: nothingType,
+    });
+
+    const rtSymbol = new RuntimeSymbol({
+        value: symbolValue,
+    });
+
+    const stSymbol = new StaticSymbol({
+        valueType: fnType,
+    });
+
+    runtimeTable.setRuntimeBinding("runtime_print_no_newline", rtSymbol);
+    analysisTable.setRuntimeBinding("runtime_print_no_newline", stSymbol);
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11,7 +11,27 @@ import {
     StaticSymbol,
 } from "./symbol.ts";
 import { FunctionSymbolType, SymbolType } from "./type.ts";
+import { InternalError } from "./util/error.ts";
 import { nothingType } from "./util/type.ts";
+
+/**
+ * Runtime bindings can be parametrized by pushing the parameter
+ * values onto the symbol table. This function retrieves the underlying
+ * values from the corresponding symbol stored in the table via a name.
+ */
+function retrieveRuntimeParameter<T>(
+    name: string,
+): T {
+    const symbol = runtimeTable.findSymbol(name)
+        .map(([symbol, _flags]) => symbol)
+        .unwrapOrThrow(
+            new InternalError(
+                "The underlying hook for a runtime binding tried to access a parameter that should have been supplied to the runtime binding.",
+                `However, the parameter called "${name}" could not be found in the symbol table.`,
+            ),
+        );
+    return symbol.value.value as T;
+}
 
 export class RuntimeStatementAstNode implements InterpretableAstNode {
     private hook!: () => void;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,6 +10,7 @@ import {
     RuntimeSymbol,
     runtimeTable,
     StaticSymbol,
+    StringSymbolValue,
     SymbolValue,
 } from "./symbol.ts";
 import { CompositeSymbolType, FunctionSymbolType, SymbolType } from "./type.ts";
@@ -128,5 +129,24 @@ export function injectRuntimeBindings() {
     analysisTable.setRuntimeBinding(
         "runtime_print_newline",
         createSingleParameterStaticSymbol("String"),
+    );
+
+    runtimeTable.setRuntimeBinding(
+        "runtime_reverse_string",
+        createSingleParameterRuntimeBinding<string>(
+            "message",
+            "String",
+            (message) => {
+                const reversed = message.split("").reverse().join("");
+                return new StringSymbolValue(reversed);
+            },
+        ),
+    );
+    analysisTable.setRuntimeBinding(
+        "runtime_reverse_string",
+        createSingleParameterStaticSymbol(
+            "String",
+            new CompositeSymbolType({ id: "String" }),
+        ),
     );
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,8 @@
+import { Token } from "typescript-parsec";
+import { InterpretableAstNode } from "./ast.ts";
 import { StatementsAstNode } from "./features/statement.ts";
+import { AnalysisFindings } from "./finding.ts";
+import { TokenKind } from "./lexer.ts";
 import {
     analysisTable,
     FunctionSymbolValue,
@@ -9,9 +13,35 @@ import {
 import { FunctionSymbolType, SymbolType } from "./type.ts";
 import { nothingType } from "./util/type.ts";
 
+export class RuntimeStatementAstNode implements InterpretableAstNode {
+    private hook!: () => void;
+
+    constructor(params: { hook: () => void }) {
+        Object.assign(this, params);
+    }
+
+    interpret(): void {
+        this.hook();
+    }
+
+    analyze(): AnalysisFindings {
+        return AnalysisFindings.empty();
+    }
+
+    tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
+        throw new Error("Method not implemented.");
+    }
+}
+
 export function injectRuntimeBindings() {
     const statements = new StatementsAstNode({
-        children: [],
+        children: [
+            new RuntimeStatementAstNode({
+                hook: () => {
+                    console.log("hello from print!");
+                },
+            }),
+        ],
     });
 
     const parameterTypes = new Map<string, SymbolType>();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -48,8 +48,18 @@ export class RuntimeStatementAstNode implements InterpretableAstNode {
         return AnalysisFindings.empty();
     }
 
+    /**
+     * It is assumed that this method is never going to be called.
+     * A `RuntimeStatementAstNode` is supposed to be the only child
+     * of a `StatementsAstNode` when it is used as a runtime binding.
+     * The `analyze` method of the `RuntimeStatementAstNode` will never
+     * yield any findings, which means that no snippet of this AST node
+     * ever has to be generated. Therefore, the token range is never accessed.
+     */
     tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
-        throw new Error("Method not implemented.");
+        throw new InternalError(
+            "The token range for a RuntimeStatementAstNode should never be accessed.",
+        );
     }
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -37,6 +37,16 @@ function resolveRuntimeParameter(
     return symbol.value;
 }
 
+/**
+ * This AST node is the key as to how runtime bindings are implemented.
+ * From the perspective of the interpreter, this AST node allows injecting
+ * native behavior into its `interpret` method via the `hook` callback.
+ * From the perspective of the language, this AST node represents a regular
+ * statement. When a runtime binding is created, a function is created that only
+ * contains a single statement, which is an instance of this AST node.
+ * Therefore, when this artificial runtime function is invocated, the language
+ * actually invokes the provided `hook`.
+ */
 export class RuntimeStatementAstNode implements InterpretableAstNode {
     private hook!: () => void;
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -16,21 +16,20 @@ export function injectRuntimeBindings() {
 
     const parameterTypes = new Map<string, SymbolType>();
     const returnType = nothingType;
-    const fnType = new FunctionSymbolType({
-        parameterTypes: Array.from(parameterTypes.values()),
-        returnType: returnType,
-    });
 
     const symbolValue = new FunctionSymbolValue({
         value: statements,
         parameterTypes: parameterTypes,
         returnType: nothingType,
     });
-
     const rtSymbol = new RuntimeSymbol({
         value: symbolValue,
     });
 
+    const fnType = new FunctionSymbolType({
+        parameterTypes: Array.from(parameterTypes.values()),
+        returnType: returnType,
+    });
     const stSymbol = new StaticSymbol({
         valueType: fnType,
     });

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -31,14 +31,18 @@ export function parseStdlib() {
 export function analyzeStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
     analysisTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
+    analysisTable.ignoreRuntimeBindings = false;
     typeTable.setGlobalFlagOverrides({ readonly: true });
+    typeTable.ignoreRuntimeTypes = false;
     const analysisFindings = stdlibAst.analyze();
     updateEnvironment({ source: "" });
     analysisTable.setGlobalFlagOverrides({
         readonly: "notset",
         stdlib: "notset",
     });
+    analysisTable.ignoreRuntimeBindings = true;
     typeTable.setGlobalFlagOverrides({ readonly: "notset" });
+    typeTable.ignoreRuntimeTypes = true;
     if (analysisFindings.errors.length !== 0) {
         throw new InternalError(
             "The standard library contains static analysis errors.",

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -8,7 +8,7 @@ import { InternalError } from "./util/error.ts";
 
 const stdlib = `
     print = function(message: String) {
-        runtime_print_no_newline()
+        runtime_print_newline(message)
     }
 `;
 

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -30,14 +30,14 @@ export function parseStdlib() {
  */
 export function analyzeStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
-    analysisTable.setGlobalFlagOverrides({ readonly: true });
+    analysisTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
     typeTable.setGlobalFlagOverrides({ readonly: true });
     const analysisFindings = stdlibAst.analyze();
-    // TODO: once a runtime is immplemented,
-    // clear runtime bindings from the symbol table, but
-    // leave stdlib members in the symbol table.
     updateEnvironment({ source: "" });
-    analysisTable.setGlobalFlagOverrides({ readonly: "notset" });
+    analysisTable.setGlobalFlagOverrides({
+        readonly: "notset",
+        stdlib: "notset",
+    });
     typeTable.setGlobalFlagOverrides({ readonly: "notset" });
     if (analysisFindings.errors.length !== 0) {
         throw new InternalError(
@@ -52,10 +52,13 @@ export function analyzeStdlib(stdlibAst: AST) {
  */
 export function injectStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
-    runtimeTable.setGlobalFlagOverrides({ readonly: true});
+    runtimeTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
     typeTable.setGlobalFlagOverrides({ readonly: true });
     stdlibAst.interpret();
-    runtimeTable.setGlobalFlagOverrides({ readonly: "notset" });
+    runtimeTable.setGlobalFlagOverrides({
+        readonly: "notset",
+        stdlib: "notset",
+    });
     typeTable.setGlobalFlagOverrides({ readonly: "notset" });
     updateEnvironment({ source: "" });
 }

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -8,7 +8,7 @@ import { InternalError } from "./util/error.ts";
 
 const stdlib = `
     print = function(message: String) {
-        // do nothing for now
+        runtime_print_no_newline()
     }
 `;
 

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -10,6 +10,10 @@ const stdlib = `
     print = function(message: String) {
         runtime_print_newline(message)
     }
+
+    reverse = function(message: String) -> String {
+        return runtime_reverse_string(message)
+    }
 `;
 
 /**

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -161,7 +161,7 @@ export class SymbolTable<S extends Symbol> {
    * When set to `true`, the table will act as if symbols stored
    * in the `runtimeBindings` namespace do not exist.
    */
-  private ignoreRuntimeBindings = true;
+  ignoreRuntimeBindings = true;
   /**
    * When a flag is set globally as an override, it is automatically
    * applied to all symbols that are inserted into the table.

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -271,7 +271,7 @@ export class SymbolTable<S extends Symbol> {
   /**
    * See the `globalFlagOverrides` attribute for more information.
    */
-  getGlobalFlagOverride(
+  private getGlobalFlagOverride(
     flag: keyof SymbolFlags,
   ): SymbolFlags[keyof SymbolFlags] {
     const override = this.globalFlagOverrides[flag];

--- a/src/type.ts
+++ b/src/type.ts
@@ -680,8 +680,23 @@ export class UniqueSymbolType implements SymbolType {
   }
 }
 
+/**
+ * Additional flags that apply to types only
+ * when they areinserted into the type table.
+ */
 type TypeFlags = {
+  /**
+   * Whether the type is readonly.
+   * Mainly used to protect stdlib contents from being reassigned.
+   */
   readonly: boolean;
+  /**
+   * Marks types that are part of the runtime.
+   * These types are not supposed to be exposed to the user.
+   * If the `ignoreRuntimeBindings` attribute in the table is set to `true`,
+   * the table will act as if the runtime types do not exist.
+   */
+  runtimeBinding: boolean;
 };
 
 type TypeEntry = TypeFlags & {
@@ -708,6 +723,7 @@ export class TypeTable {
     [K in keyof TypeFlags]: TypeFlags[K] | "notset";
   } = {
     readonly: "notset",
+    runtimeBinding: "notset",
   };
 
   constructor() {

--- a/src/type.ts
+++ b/src/type.ts
@@ -727,7 +727,7 @@ export class TypeTable {
    * When set to `true`, the table will act as if types stored
    * in the `runtimeTypes` namespace do not exists.
    */
-  private ignoreRuntimeTypes = true;
+  ignoreRuntimeTypes = true;
 
   constructor() {
     this.reset();

--- a/src/type.ts
+++ b/src/type.ts
@@ -883,7 +883,9 @@ export class TypeTable {
   /**
    * See the `globalFlagOverrides` attribute for more information.
    */
-  getGlobalFlagOverride(flag: keyof TypeFlags): TypeFlags[keyof TypeFlags] {
+  private getGlobalFlagOverride(
+    flag: keyof TypeFlags,
+  ): TypeFlags[keyof TypeFlags] {
     const override = this.globalFlagOverrides[flag];
     if (override === "notset") {
       return false;

--- a/src/type.ts
+++ b/src/type.ts
@@ -690,13 +690,6 @@ type TypeFlags = {
    * Mainly used to protect stdlib contents from being reassigned.
    */
   readonly: boolean;
-  /**
-   * Marks types that are part of the runtime.
-   * These types are not supposed to be exposed to the user.
-   * If the `ignoreRuntimeBindings` attribute in the table is set to `true`,
-   * the table will act as if the runtime types do not exist.
-   */
-  runtimeBinding: boolean;
 };
 
 type TypeEntry = TypeFlags & {
@@ -729,7 +722,6 @@ export class TypeTable {
     [K in keyof TypeFlags]: TypeFlags[K] | "notset";
   } = {
     readonly: "notset",
-    runtimeBinding: "notset",
   };
   /**
    * When set to `true`, the table will act as if types stored


### PR DESCRIPTION
This PR adds a rudimentary runtime to the language. The bindings are only accessible from the standard library. This change also adds infrastructure to easily extend the runtime in a declarative manner.

The following runtime bindings are available at this point:
- `runtime_print_newline`: Write a string to the interpreters stdout or the browsers console
- `runtime_reverse_string`: Reverses the order of characters in a string. This binding serves as an example of a runtime function that returns a value