### PR TITLE
Interface with the outside world via text-based streams

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ function run(input_file_path: string) {
     Deno.stderr.writeSync(new TextEncoder().encode(chunk));
   });
   const stdin = new VirtualTextFile();
-  onReadLine(Deno.stdin, (line) => {
+  const stdinReadSubscription = onReadLine(Deno.stdin, (line) => {
     stdin.writeLine(line);
   });
   try {
@@ -41,6 +41,7 @@ function run(input_file_path: string) {
   } catch (error) {
     logger.error(error);
   }
+  stdinReadSubscription.cancel();
   stdout.close();
   stderr.close();
   stdin.close();

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,18 +3,24 @@ import { tokenize } from "./lexer.ts";
 import { parse } from "./parser.ts";
 import { injectRuntimeBindings } from "./runtime.ts";
 import { analyzeStdlib, injectStdlib, parseStdlib } from "./stdlib.ts";
+import { FileLike, VirtualTextFile } from "./streams.ts";
 import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
 
 export type {
   AnalysisFinding,
   AnalysisFindingKind,
-  AnalysisFindings,
+  AnalysisFindings
 } from "./finding.ts";
 export type { Option, Result } from "./util/monad/index.ts";
 
-export function run(source: string): AnalysisFindings {
-  injectRuntimeBindings();
+export function run(
+  source: string,
+  stdout: FileLike<string> = new VirtualTextFile(),
+  stderr: FileLike<string> = new VirtualTextFile(),
+  stdin: FileLike<string> = new VirtualTextFile(),
+): AnalysisFindings {
+  injectRuntimeBindings(false, stdout, stderr, stdin);
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export function run(source: string): AnalysisFindings {
 }
 
 export function analyze(source: string): AnalysisFindings {
-  // TODO: inject runtime bindings
+  injectRuntimeBindings(true);
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);
   updateEnvironment({ source: source });

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export type {
   AnalysisFindingKind,
   AnalysisFindings
 } from "./finding.ts";
+export { VirtualTextFile } from "./streams.ts";
 export type { Option, Result } from "./util/monad/index.ts";
 
 export function run(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -141,7 +141,7 @@ function createRuntimeBindingStaticSymbol(
 /**
  * Creates a new runtime binding and injects it into the symbol table with the
  * given `name`. The `hook` defines the behavior of the binding. Finally,
- * the `onlyAnalysis` flag can be used to only inject the binding only into the
+ * the `onlyAnalysis` flag can be used to only inject the binding into the
  * analysis table.
  */
 function createRuntimeBinding(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4,6 +4,7 @@ import { ReturnValueContainer } from "./features/function.ts";
 import { StatementsAstNode } from "./features/statement.ts";
 import { AnalysisFindings } from "./finding.ts";
 import { TokenKind } from "./lexer.ts";
+import { ReadableStream, WritableSink } from "./streams.ts";
 import {
     analysisTable,
     FunctionSymbolValue,
@@ -170,7 +171,18 @@ function createRuntimeBinding(
  */
 export function injectRuntimeBindings(
     onlyAnalysis: boolean = false,
+    stdout?: WritableSink<string>,
+    stderr?: WritableSink<string>,
+    stdin?: ReadableStream<string>,
 ) {
+    const stdStreamsDefined = [stdout, stderr, stdin]
+        .every((stream) => stream !== undefined);
+    if (onlyAnalysis && !stdStreamsDefined) {
+        throw new InternalError(
+            "The standard streams may only be omitted when the runtime bindings are injected for static analysis.",
+        );
+    }
+
     createRuntimeBinding(
         "runtime_print",
         [{

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -177,7 +177,7 @@ export function injectRuntimeBindings(
 ) {
     const stdStreamsDefined = [stdout, stderr, stdin]
         .every((stream) => stream !== undefined);
-    if (onlyAnalysis && !stdStreamsDefined) {
+    if (!onlyAnalysis && !stdStreamsDefined) {
         throw new InternalError(
             "The standard streams may only be omitted when the runtime bindings are injected for static analysis.",
         );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -184,7 +184,7 @@ export function injectRuntimeBindings(
     }
 
     createRuntimeBinding(
-        "runtime_print",
+        "runtime_print_newline",
         [{
             name: "message",
             symbolType: new CompositeSymbolType({ id: "String" }),
@@ -193,6 +193,20 @@ export function injectRuntimeBindings(
         (params) => {
             const message = params.get("message")!.value as string;
             stdout?.writeLine(message);
+        },
+        onlyAnalysis,
+    );
+
+    createRuntimeBinding(
+        "runtime_print_no_newline",
+        [{
+            name: "message",
+            symbolType: new CompositeSymbolType({ id: "String" }),
+        }],
+        nothingType,
+        (params) => {
+            const message = params.get("message")!.value as string;
+            stdout?.writeChunk(message);
         },
         onlyAnalysis,
     );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -151,16 +151,16 @@ function createRuntimeBinding(
     hook: (params: Map<string, SymbolValue>) => SymbolValue | void,
     onlyAnalysis: boolean = false,
 ) {
-    runtimeTable.setRuntimeBinding(
-        name,
-        createRuntimeBindingRuntimeSymbol(parameters, returnType, hook),
-    );
     if (!onlyAnalysis) {
-        analysisTable.setRuntimeBinding(
+        runtimeTable.setRuntimeBinding(
             name,
-            createRuntimeBindingStaticSymbol(parameters, returnType),
+            createRuntimeBindingRuntimeSymbol(parameters, returnType, hook),
         );
     }
+    analysisTable.setRuntimeBinding(
+        name,
+        createRuntimeBindingStaticSymbol(parameters, returnType),
+    );
 }
 
 /**

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -192,7 +192,7 @@ export function injectRuntimeBindings(
         nothingType,
         (params) => {
             const message = params.get("message")!.value as string;
-            console.log(message);
+            stdout?.writeLine(message);
         },
         onlyAnalysis,
     );

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -8,7 +8,11 @@ import { InternalError } from "./util/error.ts";
 
 const stdlib = `
     print = function(message: String) {
-        runtime_print(message)
+        runtime_print_newline(message)
+    }
+
+    print_no_newline = function(message: String) {
+        runtime_print_no_newline(message)
     }
 
     reverse = function(message: String) -> String {

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -8,11 +8,11 @@ import { InternalError } from "./util/error.ts";
 
 const stdlib = `
     print = function(message: String) {
-        runtime_print_newline(message)
+        runtime_print(message)
     }
 
     reverse = function(message: String) -> String {
-        return runtime_reverse_string(message)
+        return runtime_reverse(message)
     }
 `;
 

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,8 +1,8 @@
-interface ReadableTextStream {
-    onNewLine(fn: (line: string) => void): void;
-    readLine(): Promise<string>;
-    onNewChunk(fn: (chunk: string) => void): void;
-    readChunk(): Promise<string>;
+interface ReadableStream<T> {
+    onNewLine(fn: (line: T) => void): void;
+    readLine(): Promise<T>;
+    onNewChunk(fn: (chunk: T) => void): void;
+    readChunk(): Promise<T>;
     onClose(fn: () => void): void;
-    [Symbol.asyncIterator](): AsyncIterator<string>;
+    [Symbol.asyncIterator](): AsyncIterator<T>;
 }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,7 +1,7 @@
 /**
  * Allows a subscriber of a stream to manage their subscription.
  */
-type StreamSubscription = {
+export type StreamSubscription = {
     cancel(): void;
 };
 

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,0 +1,8 @@
+interface ReadableTextStream {
+    onNewLine(fn: (line: string) => void): void;
+    readLine(): Promise<string>;
+    onNewChunk(fn: (chunk: string) => void): void;
+    readChunk(): Promise<string>;
+    onClose(fn: () => void): void;
+    [Symbol.asyncIterator](): AsyncIterator<string>;
+}

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -61,6 +61,8 @@ export interface WritableSink<T> {
     close(): void;
 }
 
+export type FileLike<T> = ReadableStream<T> & WritableSink<T>;
+
 /**
  * A text based, virtual (aka. in memory) file that can can be
  * read from and written to in an asynchronous fashion.

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,14 +1,144 @@
+/**
+ * Allows a subscriber of a stream to manage their subscription.
+ */
+type StreamSubscription = {
+    cancel(): void;
+};
+
+/**
+ * Represents a readable stream of data that can be read from asynchronously.
+ * Usually paired with a writable sink that produces the data.
+ */
 export interface ReadableStream<T> {
-    onNewLine(fn: (line: T) => void): void;
+    /**
+     * Be notified when a new line has been written to the stream.
+     */
+    onNewLine(fn: (line: T) => void): StreamSubscription;
+
+    /**
+     * Wait until a new line has been written to the stream.
+     */
     readLine(): Promise<T>;
-    onNewChunk(fn: (chunk: T) => void): void;
+
+    /**
+     * Be notified when a new chunk has been written to the stream.
+     * A chunk may contain multiple lines. When a chunk is written to the file,
+     * the stream will notify all chunk subscribers once, however, it will notify
+     * all line subscribers for each line in the chunk.
+     */
+    onNewChunk(fn: (chunk: T) => void): StreamSubscription;
+
+    /**
+     * Wait until a new chunk has been written to the stream.
+     */
     readChunk(): Promise<T>;
-    onClose(fn: () => void): void;
-    [Symbol.asyncIterator](): AsyncIterator<T>;
+
+    /**
+     * Registers a callback function to be called when the stream is closed.
+     */
+    onClose(fn: () => void): StreamSubscription;
 }
 
-export interface WritableStream<T> {
+/**
+ * Represents a writable sink of data.
+ * Usually paired with a readable stream to consume the data.
+ */
+export interface WritableSink<T> {
+    /**
+     * Writes a single line to the stream.
+     */
     writeLine(line: T): void;
+
+    /**
+     * Writes a single chunk to the stream.
+     * A chunk may contain multiple lines.
+     */
     writeChunk(chunk: T): void;
+
+    /**
+     * Closes the stream by canceling all subscriptions.
+     */
     close(): void;
+}
+
+/**
+ * A text based, virtual (aka. in memory) file that can can be
+ * read from and written to in an asynchronous fashion.
+ */
+export class VirtualTextFile
+    implements ReadableStream<string>, WritableSink<string> {
+    private lineSubscribers: ((line: string) => void)[] = [];
+    private chunkSubscribers: ((chunk: string) => void)[] = [];
+    private closeSubscribers: (() => void)[] = [];
+
+    onNewLine(fn: (line: string) => void): StreamSubscription {
+        this.lineSubscribers.push(fn);
+        return {
+            cancel: () => {
+                this.lineSubscribers = this.lineSubscribers.filter(
+                    (subscriber) => subscriber !== fn,
+                );
+            },
+        };
+    }
+
+    readLine(): Promise<string> {
+        return new Promise((resolve) => {
+            const subscriber = this.onNewLine((line) => {
+                resolve(line);
+                subscriber.cancel();
+            });
+        });
+    }
+
+    onNewChunk(fn: (chunk: string) => void): StreamSubscription {
+        this.chunkSubscribers.push(fn);
+        return {
+            cancel: () => {
+                this.chunkSubscribers = this.chunkSubscribers.filter(
+                    (subscriber) => subscriber !== fn,
+                );
+            },
+        };
+    }
+
+    readChunk(): Promise<string> {
+        return new Promise((resolve) => {
+            const subscriber = this.onNewChunk((chunk) => {
+                resolve(chunk);
+                subscriber.cancel();
+            });
+        });
+    }
+
+    onClose(fn: () => void): StreamSubscription {
+        this.closeSubscribers.push(fn);
+        return {
+            cancel: () => {
+                this.closeSubscribers = this.closeSubscribers.filter(
+                    (subscriber) => subscriber !== fn,
+                );
+            },
+        };
+    }
+
+    writeLine(line: string): void {
+        this.chunkSubscribers.forEach((subscriber) => subscriber(line));
+        this.lineSubscribers.forEach((subscriber) => subscriber(line));
+    }
+
+    writeChunk(chunk: string): void {
+        this.chunkSubscribers.forEach((subscriber) => subscriber(chunk));
+        chunk.split("\n")
+            .forEach((line) => {
+                this.lineSubscribers.forEach((subscriber) => subscriber(line));
+            });
+    }
+
+    close(): void {
+        this.chunkSubscribers = [];
+        this.lineSubscribers = [];
+        this.closeSubscribers.forEach((subscriber) => subscriber());
+        this.closeSubscribers = [];
+    }
 }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,8 +1,14 @@
-interface ReadableStream<T> {
+export interface ReadableStream<T> {
     onNewLine(fn: (line: T) => void): void;
     readLine(): Promise<T>;
     onNewChunk(fn: (chunk: T) => void): void;
     readChunk(): Promise<T>;
     onClose(fn: () => void): void;
     [Symbol.asyncIterator](): AsyncIterator<T>;
+}
+
+export interface WritableStream<T> {
+    writeLine(line: T): void;
+    writeChunk(chunk: T): void;
+    close(): void;
 }

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,0 +1,65 @@
+import { StreamSubscription } from "../streams.ts";
+
+class LineSplitterStream extends TransformStream<string, string> {
+  private buffer: string = "";
+
+  constructor() {
+    super({
+      transform: (chunk, controller) => {
+        this.buffer += chunk;
+        const lines = this.buffer.split("\n");
+        this.buffer = lines.pop()!;
+        for (const line of lines) {
+          controller.enqueue(line);
+        }
+      },
+      flush: (controller) => {
+        if (this.buffer) {
+          controller.enqueue(this.buffer);
+        }
+      },
+    });
+  }
+}
+
+/**
+ * An abstraction over reading lines from a file that would otherwise require
+ * working with the stream API directly. For every new line in the `file`, the
+ * `onLine` callback is invoked. Returns a subscription that can be used to cancel
+ * reading from the file prematurely (before the file itself is closed).
+ */
+export function onReadLine(
+  file: { readable: ReadableStream<Uint8Array> },
+  onLine: (line: string) => void,
+): StreamSubscription {
+  const readable = file.readable
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new LineSplitterStream());
+  const reader = readable.getReader();
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+  const subscription = {
+    cancel: () => {
+      abortController.abort();
+      reader.cancel();
+    },
+  };
+  (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || signal.aborted) {
+          break;
+        }
+        onLine(value);
+      }
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        throw error;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+  return subscription;
+}

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -54,7 +54,8 @@ export function onReadLine(
         onLine(value);
       }
     } catch (error) {
-      if (error.name !== "AbortError") {
+      const typedError = error as { name?: string };
+      if (typedError?.name && typedError.name !== "AbortError") {
         throw error;
       }
     } finally {


### PR DESCRIPTION
This PR adds support for standard streams (stdout, stdin, stderr) to the runtime. When the interpreter is run as a standalone command line app, these streams are wired up to the corresponding streams of the interpreter process - meaning that when a piece of text is written to stdout in the language, it appears in the console where the interpreter has been launched from. When the interpreter is instead launched via its library API, is is possible to pass in a virtual file for each of the streams.
The runtime has gained access to these streams, which can be accessed via the standard library. More specifically, the `print` and `print_no_newline` functions provide write access to stdout.

Limitations:
- It is not possible yet to access the streams as objects in the interpreted language. Streams can only be accessed indirectly via functions in the stdlib.
- The runtime/stdlib do not provide access to stderr yet, as it is still to be evaluated whether a separate error stream is truly necessary in an easy-to-learn language.
- The runtime cannot read from stdin yet. Reading from a stream that spontaneously provides data is an asynchronous operation. The language, however, does not have a concept of asynchronicity yet, making it difficult to map stdin access within the language to stdin access within the interpreter. One way to solve this would be to block the interpreter until stdin provides data, but executing a promise synchronously in javascript is impractical at best. Technically, the entire execution/evaluation chain of the interpreter could be moved to an async implementation, however, since the language is supposed to gain async support in some way in the future, it might be best to wait until that is available.