### PR TITLE
Fixed repeating invocations of the interpreter via its API leading to crashes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,13 +4,14 @@ import { parse } from "./parser.ts";
 import { injectRuntimeBindings } from "./runtime.ts";
 import { analyzeStdlib, injectStdlib, parseStdlib } from "./stdlib.ts";
 import { FileLike, VirtualTextFile } from "./streams.ts";
+import { analysisTable, runtimeTable } from "./symbol.ts";
 import { typeTable } from "./type.ts";
 import { updateEnvironment } from "./util/environment.ts";
 
 export type {
   AnalysisFinding,
   AnalysisFindingKind,
-  AnalysisFindings
+  AnalysisFindings,
 } from "./finding.ts";
 export { VirtualTextFile } from "./streams.ts";
 export type { Option, Result } from "./util/monad/index.ts";
@@ -21,6 +22,9 @@ export function run(
   stderr: FileLike<string> = new VirtualTextFile(),
   stdin: FileLike<string> = new VirtualTextFile(),
 ): AnalysisFindings {
+  typeTable.reset();
+  analysisTable.reset(false);
+  runtimeTable.reset(false);
   injectRuntimeBindings(false, stdout, stderr, stdin);
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);
@@ -37,6 +41,8 @@ export function run(
 }
 
 export function analyze(source: string): AnalysisFindings {
+  typeTable.reset();
+  analysisTable.reset(true);
   injectRuntimeBindings(true);
   const stdlibAst = parseStdlib();
   analyzeStdlib(stdlibAst);

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -125,7 +125,7 @@ export class VirtualTextFile
     }
 
     writeLine(line: string): void {
-        this.chunkSubscribers.forEach((subscriber) => subscriber(line));
+        this.chunkSubscribers.forEach((subscriber) => subscriber(`${line}\n`));
         this.lineSubscribers.forEach((subscriber) => subscriber(line));
     }
 

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -293,6 +293,23 @@ export class SymbolTable<S extends Symbol> {
       this.globalFlagOverrides[key as keyof SymbolFlags] = value;
     }
   }
+
+  /**
+   * Resets the symbol table to its initial state. Runtime bindings are wiped as well,
+   * unless the `keepRuntimeBindings` flag is set to `true` (default setting).
+   */
+  reset(
+    keepRuntimeBindings = true,
+  ) {
+    this.scopes = [new Map()];
+    if (!keepRuntimeBindings) {
+      this.runtimeBindings = new Map();
+    }
+    this.globalFlagOverrides = {
+      readonly: "notset",
+      stdlib: "notset",
+    };
+  }
 }
 
 export const analysisTable: AnalysisSymbolTable = new SymbolTable();


### PR DESCRIPTION
This PR fixes an issue that arises when the interpreter is invoked mulitple times when used as a library. The symbol and type tables were not reset between invocations, leading to analysis-findings (errors) that prevented execution of the source.