### PR TITLE
Automatically create backpressure on standard streams when no subscribers are connected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,11 @@ export type {
   AnalysisFindings,
 } from "./finding.ts";
 export { VirtualTextFile } from "./streams.ts";
+export type {
+  ReadableStream,
+  StreamSubscription,
+  WritableSink,
+} from "./streams.ts";
 export type { Option, Result } from "./util/monad/index.ts";
 
 export function run(

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -190,5 +190,6 @@ export class VirtualTextFile
         this.lineSubscribers = [];
         this.closeSubscribers.forEach((subscriber) => subscriber());
         this.closeSubscribers = [];
+        this.lineBuffer.clear();
     }
 }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,3 +1,5 @@
+import { FixedSizeQueue } from "./util/array.ts";
+
 /**
  * Allows a subscriber of a stream to manage their subscription.
  */
@@ -66,14 +68,24 @@ export type FileLike<T> = ReadableStream<T> & WritableSink<T>;
 /**
  * A text based, virtual (aka. in memory) file that can can be
  * read from and written to in an asynchronous fashion.
+ * Automatically creates backpressure when there are no subscribers
+ * to the stream by buffering the most recent `bufferSize` lines.
  */
 export class VirtualTextFile
     implements ReadableStream<string>, WritableSink<string> {
     private lineSubscribers: ((line: string) => void)[] = [];
     private chunkSubscribers: ((chunk: string) => void)[] = [];
     private closeSubscribers: (() => void)[] = [];
+    private lineBuffer: FixedSizeQueue<string>;
+
+    constructor(bufferSize: number = 500) {
+        this.lineBuffer = new FixedSizeQueue(bufferSize);
+    }
 
     onNewLine(fn: (line: string) => void): StreamSubscription {
+        while (this.lineBuffer.size() > 0) {
+            fn(this.lineBuffer.dequeue()!);
+        }
         this.lineSubscribers.push(fn);
         return {
             cancel: () => {
@@ -86,6 +98,10 @@ export class VirtualTextFile
 
     readLine(): Promise<string> {
         return new Promise((resolve) => {
+            if (this.lineBuffer.size() > 0) {
+                resolve(this.lineBuffer.dequeue()!);
+                return;
+            }
             const subscriber = this.onNewLine((line) => {
                 resolve(line);
                 subscriber.cancel();
@@ -94,6 +110,13 @@ export class VirtualTextFile
     }
 
     onNewChunk(fn: (chunk: string) => void): StreamSubscription {
+        while (this.lineBuffer.size() > 1) {
+            const line = this.lineBuffer.dequeue()!;
+            fn(`${line}\n`);
+        }
+        if (this.lineBuffer.size() === 1) {
+            fn(this.lineBuffer.get(-1)!);
+        }
         this.chunkSubscribers.push(fn);
         return {
             cancel: () => {
@@ -106,6 +129,15 @@ export class VirtualTextFile
 
     readChunk(): Promise<string> {
         return new Promise((resolve) => {
+            if (this.lineBuffer.size() > 1) {
+                const line = this.lineBuffer.dequeue()!;
+                resolve(`${line}\n`);
+                return;
+            }
+            if (this.lineBuffer.size() === 1) {
+                resolve(this.lineBuffer.get(-1)!);
+                return;
+            }
             const subscriber = this.onNewChunk((chunk) => {
                 resolve(chunk);
                 subscriber.cancel();
@@ -125,14 +157,30 @@ export class VirtualTextFile
     }
 
     writeLine(line: string): void {
+        const anySubscribers = [
+            this.chunkSubscribers.length,
+            this.lineSubscribers.length,
+        ]
+            .some((length) => length > 0);
+        if (!anySubscribers) {
+            this.lineBuffer.enqueue(line);
+        }
         this.chunkSubscribers.forEach((subscriber) => subscriber(`${line}\n`));
         this.lineSubscribers.forEach((subscriber) => subscriber(line));
     }
 
     writeChunk(chunk: string): void {
+        const anySubscribers = [
+            this.chunkSubscribers.length,
+            this.lineSubscribers.length,
+        ]
+            .some((length) => length > 0);
         this.chunkSubscribers.forEach((subscriber) => subscriber(chunk));
         chunk.split("\n")
             .forEach((line) => {
+                if (!anySubscribers) {
+                    this.lineBuffer.enqueue(line);
+                }
                 this.lineSubscribers.forEach((subscriber) => subscriber(line));
             });
     }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -161,8 +161,7 @@ export class VirtualTextFile
         const anySubscribers = [
             this.chunkSubscribers.length,
             this.lineSubscribers.length,
-        ]
-            .some((length) => length > 0);
+        ].some((length) => length > 0);
         if (!anySubscribers) {
             this.lineBuffer.enqueue(line);
         }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -74,6 +74,7 @@ export class VirtualTextFile
     onNewChunk(fn: (chunk: string) => void): StreamSubscription {
         let disableBufferFlush = false;
         setTimeout(() => {
+            this.subscribers.push(fn);
             while (this.lineBuffer.size() >= 2) {
                 if (disableBufferFlush) {
                     return;
@@ -86,7 +87,6 @@ export class VirtualTextFile
                     fn(this.lineBuffer.dequeue()!);
                 }
             }
-            this.subscribers.push(fn);
         }, 0);
         return {
             cancel: () => {

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -177,9 +177,13 @@ export class VirtualTextFile
             .some((length) => length > 0);
         this.chunkSubscribers.forEach((subscriber) => subscriber(chunk));
         chunk.split("\n")
-            .forEach((line) => {
+            .forEach((line, index) => {
                 if (!anySubscribers) {
-                    this.lineBuffer.enqueue(line);
+                    if (index === 0) {
+                        this.lineBuffer.edit(-1, line);
+                    } else {
+                        this.lineBuffer.enqueue(line);
+                    }
                 }
                 this.lineSubscribers.forEach((subscriber) => subscriber(line));
             });

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -116,7 +116,7 @@ export class VirtualTextFile
             fn(`${line}\n`);
         }
         if (this.lineBuffer.size() === 1) {
-            fn(this.lineBuffer.get(-1)!);
+            fn(this.lineBuffer.get(-1));
         }
         this.chunkSubscribers.push(fn);
         return {
@@ -136,7 +136,7 @@ export class VirtualTextFile
                 return;
             }
             if (this.lineBuffer.size() === 1) {
-                resolve(this.lineBuffer.get(-1)!);
+                resolve(this.lineBuffer.get(-1));
                 return;
             }
             const subscriber = this.onNewChunk((chunk) => {

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -166,7 +166,10 @@ export class VirtualTextFile
             this.lineBuffer.enqueue(line);
         }
         this.chunkSubscribers.forEach((subscriber) => subscriber(`${line}\n`));
-        this.lineSubscribers.forEach((subscriber) => subscriber(line));
+        this.lineSubscribers.forEach((subscriber) =>
+            subscriber(`${this.currentLineBuffer}${line}`)
+        );
+        this.currentLineBuffer = "";
     }
 
     writeChunk(chunk: string): void {

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -86,8 +86,8 @@ export class VirtualTextFile
                     fn(this.lineBuffer.dequeue()!);
                 }
             }
+            this.subscribers.push(fn);
         }, 0);
-        this.subscribers.push(fn);
         return {
             cancel: () => {
                 disableBufferFlush = true;
@@ -144,9 +144,11 @@ export class VirtualTextFile
     }
 
     close(): void {
-        this.subscribers = [];
-        this.lineBuffer.clear();
-        this.closeSubscribers.forEach((subscriber) => subscriber());
-        this.closeSubscribers = [];
+        setTimeout(() => {
+            this.subscribers = [];
+            this.lineBuffer.clear();
+            this.closeSubscribers.forEach((subscriber) => subscriber());
+            this.closeSubscribers = [];
+        }, 0);
     }
 }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -13,16 +13,6 @@ export type StreamSubscription = {
  */
 export interface ReadableStream<T> {
     /**
-     * Be notified when a new line has been written to the stream.
-     */
-    onNewLine(fn: (line: T) => void): StreamSubscription;
-
-    /**
-     * Wait until a new line has been written to the stream.
-     */
-    readLine(): Promise<T>;
-
-    /**
      * Be notified when a new chunk has been written to the stream.
      * A chunk may contain multiple lines. When a chunk is written to the file,
      * the stream will notify all chunk subscribers once, however, it will notify
@@ -70,24 +60,15 @@ export type FileLike<T> = ReadableStream<T> & WritableSink<T>;
  * read from and written to in an asynchronous fashion.
  * Automatically creates backpressure when there are no subscribers
  * to the stream by buffering the most recent `bufferSize` lines.
- * This file only handles reads/writes in chunks. See `VirtualTextFile`
- * for a file that can handle these operations for chunks as well as lines.
  */
-class ChunkBasedVirtualFile {
+export class VirtualTextFile
+    implements ReadableStream<string>, WritableSink<string> {
     private subscribers: ((chunk: string) => void)[] = [];
+    private closeSubscribers: (() => void)[] = [];
     private lineBuffer: FixedSizeQueue<string>;
 
     constructor(bufferSize: number = 500) {
         this.lineBuffer = new FixedSizeQueue(bufferSize);
-    }
-
-    readChunk(): Promise<string> {
-        return new Promise((resolve) => {
-            const subscriber = this.onNewChunk((chunk) => {
-                resolve(chunk);
-                subscriber.cancel();
-            });
-        });
     }
 
     onNewChunk(fn: (chunk: string) => void): StreamSubscription {
@@ -117,6 +98,19 @@ class ChunkBasedVirtualFile {
         };
     }
 
+    readChunk(): Promise<string> {
+        return new Promise((resolve) => {
+            const subscriber = this.onNewChunk((chunk) => {
+                resolve(chunk);
+                subscriber.cancel();
+            });
+        });
+    }
+
+    writeLine(line: string): void {
+        this.writeChunk(`${line}\n`);
+    }
+
     writeChunk(chunk: string): void {
         const anySubscribers = this.subscribers.length > 0;
         const lines = chunk.split("\n");
@@ -138,93 +132,6 @@ class ChunkBasedVirtualFile {
         }
     }
 
-    close(): void {
-        this.subscribers = [];
-        this.lineBuffer.clear();
-    }
-}
-
-/**
- * A text based, virtual (aka. in memory) file that can can be
- * read from and written to in an asynchronous fashion.
- * Automatically creates backpressure when there are no subscribers
- * to the stream by buffering the most recent `bufferSize` lines.
- */
-export class VirtualTextFile
-    implements ReadableStream<string>, WritableSink<string> {
-    private lineSubscribers: ((line: string) => void)[] = [];
-    private chunkSubscribers: ((chunk: string) => void)[] = [];
-    private closeSubscribers: (() => void)[] = [];
-    private lineBuffer: FixedSizeQueue<string>;
-    private currentLineBuffer = "";
-
-    constructor(bufferSize: number = 500) {
-        this.lineBuffer = new FixedSizeQueue(bufferSize);
-    }
-
-    onNewLine(fn: (line: string) => void): StreamSubscription {
-        while (this.lineBuffer.size() > 1) {
-            fn(this.lineBuffer.dequeue()!);
-        }
-        this.lineSubscribers.push(fn);
-        return {
-            cancel: () => {
-                this.lineSubscribers = this.lineSubscribers.filter(
-                    (subscriber) => subscriber !== fn,
-                );
-            },
-        };
-    }
-
-    readLine(): Promise<string> {
-        return new Promise((resolve) => {
-            if (this.lineBuffer.size() > 1) {
-                resolve(this.lineBuffer.dequeue()!);
-                return;
-            }
-            const subscriber = this.onNewLine((line) => {
-                resolve(line);
-                subscriber.cancel();
-            });
-        });
-    }
-
-    onNewChunk(fn: (chunk: string) => void): StreamSubscription {
-        while (this.lineBuffer.size() > 1) {
-            const line = this.lineBuffer.dequeue()!;
-            fn(`${line}\n`);
-        }
-        if (this.lineBuffer.size() === 1) {
-            fn(this.lineBuffer.get(-1));
-        }
-        this.chunkSubscribers.push(fn);
-        return {
-            cancel: () => {
-                this.chunkSubscribers = this.chunkSubscribers.filter(
-                    (subscriber) => subscriber !== fn,
-                );
-            },
-        };
-    }
-
-    readChunk(): Promise<string> {
-        return new Promise((resolve) => {
-            if (this.lineBuffer.size() > 1) {
-                const line = this.lineBuffer.dequeue()!;
-                resolve(`${line}\n`);
-                return;
-            }
-            if (this.lineBuffer.size() === 1) {
-                resolve(this.lineBuffer.get(-1));
-                return;
-            }
-            const subscriber = this.onNewChunk((chunk) => {
-                resolve(chunk);
-                subscriber.cancel();
-            });
-        });
-    }
-
     onClose(fn: () => void): StreamSubscription {
         this.closeSubscribers.push(fn);
         return {
@@ -236,60 +143,10 @@ export class VirtualTextFile
         };
     }
 
-    writeLine(line: string): void {
-        const anySubscribers = [
-            this.chunkSubscribers.length,
-            this.lineSubscribers.length,
-        ].some((length) => length > 0);
-        if (!anySubscribers) {
-            this.lineBuffer.enqueue(line);
-        }
-        this.chunkSubscribers.forEach((subscriber) => subscriber(`${line}\n`));
-        this.lineSubscribers.forEach((subscriber) =>
-            subscriber(`${this.currentLineBuffer}${line}`)
-        );
-        this.currentLineBuffer = "";
-    }
-
-    writeChunk(chunk: string): void {
-        const anySubscribers = [
-            this.chunkSubscribers.length,
-            this.lineSubscribers.length,
-        ].some((length) => length > 0);
-        const lines = chunk.split("\n");
-        const enqueue = this.lineBuffer.enqueue.bind(this.lineBuffer);
-        if (!anySubscribers) {
-            if (this.lineBuffer.isEmpty()) {
-                lines.forEach(enqueue);
-            } else {
-                lines.slice(0, 1).forEach((line) => {
-                    this.lineBuffer.apply(
-                        0,
-                        (current) => `${current}${line}`,
-                    );
-                });
-                lines.slice(1).forEach(enqueue);
-            }
-        } else {
-            this.chunkSubscribers.forEach((subscriber) => subscriber(chunk));
-            lines.slice(0, 1).forEach((line) => {
-                this.lineSubscribers.forEach((subscriber) =>
-                    subscriber(`${this.currentLineBuffer}${line}`)
-                );
-                this.currentLineBuffer = "";
-            });
-            lines.slice(1, -1).forEach((line) => {
-                this.lineSubscribers.forEach((subscriber) => subscriber(line));
-            });
-            this.currentLineBuffer = lines[lines.length - 1] ?? "";
-        }
-    }
-
     close(): void {
-        this.chunkSubscribers = [];
-        this.lineSubscribers = [];
+        this.subscribers = [];
+        this.lineBuffer.clear();
         this.closeSubscribers.forEach((subscriber) => subscriber());
         this.closeSubscribers = [];
-        this.lineBuffer.clear();
     }
 }

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -164,7 +164,18 @@ export class FixedSizeQueue<T> {
     this.queue[index] = newValue;
   }
 
-  get(index: number): T | undefined {
+  /**
+   * Replaces the element at the given index with a new value.
+   * The new value is calculated by applying the given function
+   * to the current value. The index can be negative to access
+   * elements starting from the end of the queue.
+   */
+  apply(index: number, fn: (item: T) => T): void {
+    const current = this.get(index);
+    this.edit(index, fn(current));
+  }
+
+  get(index: number): T {
     const distance = index < 0 ? (-1 * index) - 1 : index;
     if (distance >= this.queue.length) {
       throw new InternalError(

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -1,3 +1,5 @@
+import { InternalError } from "./error.ts";
+
 export function range(n: number, m: number): number[] {
   const result = [];
   for (let i = n; i <= m; i++) {
@@ -104,4 +106,100 @@ export function zip<T, U>(a: T[], b: U[]): [T, U, number][] {
   const shortestArrayLength = Math.min(a.length, b.length);
   const trimmedA = a.slice(0, shortestArrayLength);
   return trimmedA.map((item, index) => [item, b[index], index]);
+}
+
+/**
+ * A queue with a fixed size that removes the oldest element when full.
+ */
+export class FixedSizeQueue {
+  private queue: string[] = [];
+
+  constructor(private maxSize: number) {
+    if (this.maxSize <= 0) {
+      throw new InternalError(
+        "The max. size of a FixedSizeQueue must be greater than 0",
+      );
+    }
+  }
+
+  /**
+   * Adds an element to the queue. If the queue is full, the oldest element is removed.
+   */
+  enqueue(item: string): void {
+    if (this.queue.length >= this.maxSize) {
+      this.queue.shift();
+    }
+    this.queue.push(item);
+  }
+
+  /**
+   * Removes and returns the oldest element from the queue.
+   */
+  dequeue(): string | undefined {
+    return this.queue.shift();
+  }
+
+  /**
+   * Returns the oldest element from the queue without removing it.
+   */
+  peek(): string | undefined {
+    return this.queue[0];
+  }
+
+  /**
+   * Replaces the element at the given index with a new value.
+   * The index can be negative to access elements starting
+   * from the end of the queue.
+   */
+  edit(index: number, newValue: string): void {
+    const distance = index < 0 ? (-1 * index) - 1 : index;
+    if (distance >= this.queue.length) {
+      throw new InternalError(
+        `The FixedSizeQueue does not have an element at index ${index}`,
+      );
+    }
+    if (index < 0) {
+      index = this.queue.length - distance - 1;
+    }
+    this.queue[index] = newValue;
+  }
+
+  get(index: number): string | undefined {
+    const distance = index < 0 ? (-1 * index) - 1 : index;
+    if (distance >= this.queue.length) {
+      throw new InternalError(
+        `The FixedSizeQueue does not have an element at index ${index}`,
+      );
+    }
+    if (index < 0) {
+      return this.queue[this.queue.length - distance - 1];
+    }
+    return this.queue[index];
+  }
+
+  size(): number {
+    return this.queue.length;
+  }
+
+  isFull(): boolean {
+    return this.queue.length === this.maxSize;
+  }
+
+  isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+
+  /**
+   * Returns the array of elements in the queue without copying it.
+   */
+  underlyingElements(): string[] {
+    return this.queue;
+  }
+
+  /**
+   * Returns a copy of the array of elements in the queue.
+   */
+  copyUnderlyingElements(): string[] {
+    return [...this.queue];
+  }
 }

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -111,8 +111,8 @@ export function zip<T, U>(a: T[], b: U[]): [T, U, number][] {
 /**
  * A queue with a fixed size that removes the oldest element when full.
  */
-export class FixedSizeQueue {
-  private queue: string[] = [];
+export class FixedSizeQueue<T> {
+  private queue: T[] = [];
 
   constructor(private maxSize: number) {
     if (this.maxSize <= 0) {
@@ -125,7 +125,7 @@ export class FixedSizeQueue {
   /**
    * Adds an element to the queue. If the queue is full, the oldest element is removed.
    */
-  enqueue(item: string): void {
+  enqueue(item: T): void {
     if (this.queue.length >= this.maxSize) {
       this.queue.shift();
     }
@@ -135,14 +135,14 @@ export class FixedSizeQueue {
   /**
    * Removes and returns the oldest element from the queue.
    */
-  dequeue(): string | undefined {
+  dequeue(): T | undefined {
     return this.queue.shift();
   }
 
   /**
    * Returns the oldest element from the queue without removing it.
    */
-  peek(): string | undefined {
+  peek(): T | undefined {
     return this.queue[0];
   }
 
@@ -151,7 +151,7 @@ export class FixedSizeQueue {
    * The index can be negative to access elements starting
    * from the end of the queue.
    */
-  edit(index: number, newValue: string): void {
+  edit(index: number, newValue: T): void {
     const distance = index < 0 ? (-1 * index) - 1 : index;
     if (distance >= this.queue.length) {
       throw new InternalError(
@@ -164,7 +164,7 @@ export class FixedSizeQueue {
     this.queue[index] = newValue;
   }
 
-  get(index: number): string | undefined {
+  get(index: number): T | undefined {
     const distance = index < 0 ? (-1 * index) - 1 : index;
     if (distance >= this.queue.length) {
       throw new InternalError(
@@ -192,14 +192,14 @@ export class FixedSizeQueue {
   /**
    * Returns the array of elements in the queue without copying it.
    */
-  underlyingElements(): string[] {
+  underlyingElements(): T[] {
     return this.queue;
   }
 
   /**
    * Returns a copy of the array of elements in the queue.
    */
-  copyUnderlyingElements(): string[] {
+  copyUnderlyingElements(): T[] {
     return [...this.queue];
   }
 }

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -202,4 +202,11 @@ export class FixedSizeQueue<T> {
   copyUnderlyingElements(): T[] {
     return [...this.queue];
   }
+
+  /**
+   * Clears the queue.
+   */
+  clear(): void {
+    this.queue = [];
+  }
 }

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -110,6 +110,7 @@ export function zip<T, U>(a: T[], b: U[]): [T, U, number][] {
 
 /**
  * A queue with a fixed size that removes the oldest element when full.
+ * Throws an `InternalError` if the max. size is less than or equal to 0.
  */
 export class FixedSizeQueue<T> {
   private queue: T[] = [];
@@ -149,7 +150,8 @@ export class FixedSizeQueue<T> {
   /**
    * Replaces the element at the given index with a new value.
    * The index can be negative to access elements starting
-   * from the end of the queue.
+   * from the end of the queue. Throws an `InternalError` if
+   * the index is out of bounds.
    */
   edit(index: number, newValue: T): void {
     const distance = index < 0 ? (-1 * index) - 1 : index;
@@ -175,6 +177,11 @@ export class FixedSizeQueue<T> {
     this.edit(index, fn(current));
   }
 
+  /**
+   * Returns the element at the given index. The index can be negative
+   * to access elements starting from the end of the queue. Throws an
+   * `InternalError` if the index is out of bounds.
+   */
   get(index: number): T {
     const distance = index < 0 ? (-1 * index) - 1 : index;
     if (distance >= this.queue.length) {


### PR DESCRIPTION
This PR changes the behavior of the standard streams (stdout, stdin, stderr) that are exposed by the library version of the language. When no subscribers are connected, the streams automatically create backpressure by buffering incoming chunks of data. The next time a new subscriber is connected, this buffer is flushed. The interface for reading data from streams has been simplified to aid in the buffer implementation. Specifically, there is no way to query or listen for new lines anymore. Instead, consumers of the stream should listen to updates in chunks.