### PR TITLE
Enable property access

### DIFF
--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -1,4 +1,4 @@
-import { apply, tok, Token } from "typescript-parsec";
+import { apply, kright, str, tok, Token } from "typescript-parsec";
 import { EvaluableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
@@ -63,7 +63,13 @@ export class SymbolExpressionAstNode implements EvaluableAstNode {
   }
 }
 
+
 /* PARSER */
+
+const propertyAccess = kright(
+  str<TokenKind>("."),
+  tok(TokenKind.ident),
+);
 
 export const symbolExpression = apply(
   tok(TokenKind.ident),

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -90,7 +90,7 @@ class PropertyAccessAstNode implements EvaluableAstNode {
     if (findings.isErroneous()) {
       return findings;
     }
-    const parentType = this.parent.resolveType().resolve();
+    const parentType = this.parent.resolveType().peel();
     if (parentType instanceof CompositeSymbolType) {
       const fieldExists = parentType.fields.has(this.identifierToken.text);
       if (fieldExists) {
@@ -113,7 +113,7 @@ class PropertyAccessAstNode implements EvaluableAstNode {
   resolveType(): SymbolType {
     const parentType = this.parent
       .resolveType()
-      .resolve() as CompositeSymbolType;
+      .peel() as CompositeSymbolType;
     const accessedType = parentType.fields.get(
       this.identifierToken.text,
     );

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -1,4 +1,4 @@
-import { apply, kright, str, tok, Token } from "typescript-parsec";
+import { apply, kright, rep_sc, seq, str, tok, Token } from "typescript-parsec";
 import { EvaluableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
@@ -6,10 +6,11 @@ import { analysisTable, runtimeTable, SymbolValue } from "../symbol.ts";
 import { SymbolType } from "../type.ts";
 import { InternalError } from "../util/error.ts";
 import { None } from "../util/monad/index.ts";
+import { Attributes } from "../util/type.ts";
 
 /* AST NODES */
 
-export class SymbolExpressionAstNode implements EvaluableAstNode {
+export class ReferenceExpressionAstNode implements EvaluableAstNode {
   identifierToken: Token<TokenKind>;
 
   constructor(identifier: Token<TokenKind>) {
@@ -63,6 +64,60 @@ export class SymbolExpressionAstNode implements EvaluableAstNode {
   }
 }
 
+class PropertyAccessAstNode implements EvaluableAstNode {
+  identifierToken!: Token<TokenKind>;
+  parent!: EvaluableAstNode;
+
+  constructor(params: Attributes<PropertyAccessAstNode>) {
+    Object.assign(this, params);
+  }
+
+  evaluate(): SymbolValue<unknown> {
+    const ident = this.identifierToken.text;
+    return runtimeTable
+      .findSymbol(ident)
+      .map(([symbol, _flags]) => symbol.value)
+      .unwrapOrThrow(
+        new InternalError(
+          `Unable to resolve symbol ${ident} in the symbol table.`,
+          "This should have been caught during static analysis.",
+        ),
+      );
+  }
+
+  analyze(): AnalysisFindings {
+    const ident = this.identifierToken.text;
+    const findings = AnalysisFindings.empty();
+    analysisTable.findSymbol(ident).onNone(() => {
+      findings.errors.push(
+        AnalysisError({
+          message:
+            "You tried to use a variable that has not been defined at this point in the program.",
+          beginHighlight: this,
+          endHighlight: None(),
+          messageHighlight: `Variable "${ident}" is unknown at this point.`,
+        }),
+      );
+    });
+    return findings;
+  }
+
+  resolveType(): SymbolType {
+    return analysisTable
+      .findSymbol(this.identifierToken.text)
+      .map(([symbol, _flags]) => symbol.valueType)
+      .unwrapOrThrow(
+        new InternalError(
+          "Unable to resolve a symbol in the symbol table.",
+          "This should have been caught by static analysis.",
+        ),
+      );
+  }
+
+  tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
+    return [this.identifierToken, this.identifierToken];
+  }
+}
 
 /* PARSER */
 
@@ -71,7 +126,24 @@ const propertyAccess = kright(
   tok(TokenKind.ident),
 );
 
-export const symbolExpression = apply(
+const referenceExpression = apply(
   tok(TokenKind.ident),
-  (identifier) => new SymbolExpressionAstNode(identifier),
+  (identifier) => new ReferenceExpressionAstNode(identifier),
+);
+
+export const symbolExpression = apply(
+  seq(
+    referenceExpression,
+    rep_sc(propertyAccess),
+  ),
+  ([rootSymbol, propertyAccesses]) => {
+    return propertyAccesses.reduce(
+      (parent, property) =>
+        new PropertyAccessAstNode({
+          identifierToken: property,
+          parent,
+        }),
+      rootSymbol,
+    );
+  },
 );

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -111,15 +111,19 @@ class PropertyAccessAstNode implements EvaluableAstNode {
   }
 
   resolveType(): SymbolType {
-    return analysisTable
-      .findSymbol(this.identifierToken.text)
-      .map(([symbol, _flags]) => symbol.valueType)
-      .unwrapOrThrow(
-        new InternalError(
-          "Unable to resolve a symbol in the symbol table.",
-          "This should have been caught by static analysis.",
-        ),
+    const parentType = this.parent
+      .resolveType()
+      .resolve() as CompositeSymbolType;
+    const accessedType = parentType.fields.get(
+      this.identifierToken.text,
+    );
+    if (accessedType === undefined) {
+      throw new InternalError(
+        `The property "${this.identifierToken.text}" does not exist on the object.`,
+        "This should have been caught during static analysis.",
       );
+    }
+    return accessedType;
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/type.ts
+++ b/src/type.ts
@@ -113,7 +113,7 @@ export interface SymbolType {
    * In case the type is a chain of placeholders, returns the last type in the chain.
    * In case the type is not a placeholder, returns the type itself.
    */
-  resolve(): SymbolType;
+  peel(): SymbolType;
 
   /**
    * Creates a deep copy of the type.
@@ -257,7 +257,7 @@ export class FunctionSymbolType implements SymbolType {
     return;
   }
 
-  resolve(): SymbolType {
+  peel(): SymbolType {
     return this;
   }
 
@@ -444,7 +444,7 @@ export class CompositeSymbolType implements SymbolType {
     return;
   }
 
-  resolve(): SymbolType {
+  peel(): SymbolType {
     return this;
   }
 
@@ -496,8 +496,8 @@ export class PlaceholderSymbolType implements SymbolType {
     other: SymbolType,
     mismatchHandler?: SymbolTypeMismatchHandler,
   ): boolean {
-    const resolvedA = this.resolve();
-    const resolvedB = other.resolve();
+    const resolvedA = this.peel();
+    const resolvedB = other.peel();
     const bothBound = resolvedA.bound() && resolvedB.bound();
     if (bothBound) {
       return resolvedA.typeCompatibleWith(resolvedB, mismatchHandler);
@@ -563,9 +563,9 @@ export class PlaceholderSymbolType implements SymbolType {
     this.reference = Some(to);
   }
 
-  resolve(): SymbolType {
+  peel(): SymbolType {
     return this.reference
-      .map((reference) => reference.resolve())
+      .map((reference) => reference.peel())
       .unwrapOr(this);
   }
 
@@ -661,7 +661,7 @@ export class UniqueSymbolType implements SymbolType {
     return;
   }
 
-  resolve(): SymbolType {
+  peel(): SymbolType {
     return this;
   }
 


### PR DESCRIPTION
Up to this point, it was possible to instantiate structures but not access the values stored in their fields. This PR introduces property access via the dot notation. Properties from nested structures can be accessed as well.

Example:

```
structure Address {
    street: String,
    house: Number,
}

structure Person {
    name: String,
    address: Address,
}

p = Person("Steve", Address("Main St.", 12))
print(p.name)
print(p.address.street)
```

Output:

```
Steve
Main St.
```