### PR TITLE
Allow type properties (fields) to have default values

### DIFF
--- a/src/features/condition.ts
+++ b/src/features/condition.ts
@@ -1,4 +1,12 @@
-import { apply, kmid, kright, opt_sc, seq, str, Token } from "typescript-parsec";
+import {
+  apply,
+  kmid,
+  kright,
+  opt_sc,
+  seq,
+  str,
+  Token,
+} from "typescript-parsec";
 import { InterpretableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
@@ -13,8 +21,8 @@ import {
 import { WithOptionalAttributes } from "../util/type.ts";
 import { BooleanExpressionAstNode } from "./boolean_expression.ts";
 import { expression, ExpressionAstNode } from "./expression.ts";
-import { condition } from "./parser_declarations.ts";
-import { statements, StatementsAstNode } from "./statement.ts";
+import { condition, statements } from "./parser_declarations.ts";
+import { StatementsAstNode } from "./statement.ts";
 
 /* AST NODES */
 

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -48,12 +48,12 @@ import {
 } from "../util/type.ts";
 import { ConditionAstNode } from "./condition.ts";
 import { expression, ExpressionAstNode } from "./expression.ts";
-import { functionDefinition, returnStatement } from "./parser_declarations.ts";
 import {
-  StatementAstNode,
+  functionDefinition,
+  returnStatement,
   statements,
-  StatementsAstNode,
-} from "./statement.ts";
+} from "./parser_declarations.ts";
+import { StatementAstNode, StatementsAstNode } from "./statement.ts";
 import { typeLiteral, TypeLiteralAstNode } from "./type_literal.ts";
 
 /* DATA TYPES */

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -87,6 +87,8 @@ export class InvocationAstNode implements EvaluableAstNode {
     functionType: FunctionSymbolType,
   ): AnalysisFindings {
     let findings = AnalysisFindings.empty();
+    const isConstructor = typeTable.findType(this.name.text).hasValue();
+    const construct = isConstructor ? "structure" : "function";
     functionType = functionType.fork();
     const expectedParameterTypes = functionType.parameterTypes;
     const foundParameterTypes = this.parameters
@@ -94,7 +96,7 @@ export class InvocationAstNode implements EvaluableAstNode {
     if (expectedParameterTypes.length != foundParameterTypes.length) {
       findings.errors.push(AnalysisError({
         message:
-          `The function expected ${expectedParameterTypes.length} parameters but ${foundParameterTypes.length} were supplied.`,
+          `The ${construct} expected ${expectedParameterTypes.length} parameters but ${foundParameterTypes.length} were supplied.`,
         beginHighlight: this.parameters.at(0) ??
           DummyAstNode.fromToken(this.openParenthesis),
         endHighlight: Some(

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -223,7 +223,7 @@ export class InvocationAstNode implements EvaluableAstNode {
       .map(([symbol, _flags]) => [symbol.valueType.isFunction(), true])
       .unwrapOr([false, false]);
     const calledType = typeTable.findType(this.name.text)
-      .map(([type, _flags]) => type);
+      .map(([type, _flags]) => type.peel());
     const isType = calledType.hasValue();
     if (symbolExists && isType) {
       throw new InternalError(
@@ -251,7 +251,7 @@ export class InvocationAstNode implements EvaluableAstNode {
         findings,
         this.analyzeFunctionInvocation(
           calledSymbol
-            .map(([symbol, _flags]) => symbol.valueType)
+            .map(([symbol, _flags]) => symbol.valueType.peel())
             .unwrap() as FunctionSymbolType,
         ),
       );

--- a/src/features/parser_declarations.ts
+++ b/src/features/parser_declarations.ts
@@ -1,11 +1,12 @@
 import { rule } from "typescript-parsec";
 import { TokenKind } from "../lexer.ts";
 import { ConditionAstNode } from "./condition.ts";
-import { InvocationAstNode } from "./invocation.ts";
 import {
   FunctionDefinitionAstNode,
   ReturnStatementAstNode,
 } from "./function.ts";
+import { InvocationAstNode } from "./invocation.ts";
+import { StatementsAstNode } from "./statement.ts";
 
 /*
 This file contains uninitialized parser declarations.
@@ -50,3 +51,5 @@ export const functionDefinition = rule<TokenKind, FunctionDefinitionAstNode>();
 export const returnStatement = rule<TokenKind, ReturnStatementAstNode>();
 
 export const invocation = rule<TokenKind, InvocationAstNode>();
+
+export const statements = rule<TokenKind, StatementsAstNode>();

--- a/src/features/statement.ts
+++ b/src/features/statement.ts
@@ -8,12 +8,16 @@ import { Attributes } from "../util/type.ts";
 import { assignment, AssignmentAstNode } from "./assignment.ts";
 import { expression, ExpressionAstNode } from "./expression.ts";
 // required for extension methods to be usable
+import { RuntimeStatementAstNode } from "../runtime.ts";
 import {} from "../util/array.ts";
 import { ConditionAstNode } from "./condition.ts";
 import { ReturnStatementAstNode } from "./function.ts";
-import { condition, returnStatement } from "./parser_declarations.ts";
+import {
+  condition,
+  returnStatement,
+  statements,
+} from "./parser_declarations.ts";
 import { structureDefinition, StructureDefinitonAstNode } from "./structure.ts";
-import { RuntimeStatementAstNode } from "../runtime.ts";
 
 /* AST NODES */
 
@@ -70,14 +74,16 @@ const statement = alt_sc(
   expression,
 );
 
-export const statements = apply(
-  opt_sc(
-    list_sc(
-      statement,
-      tok(TokenKind.breakingWhitespace),
+statements.setPattern(
+  apply(
+    opt_sc(
+      list_sc(
+        statement,
+        tok(TokenKind.breakingWhitespace),
+      ),
     ),
+    (statements) => new StatementsAstNode({ children: statements ?? [] }),
   ),
-  (statements) => new StatementsAstNode({ children: statements ?? [] }),
 );
 
 export const globalStatements = surround_with_breaking_whitespace(statements);

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -68,7 +68,10 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
    * using a `PlaceholderSymbolType`.
    */
   resolvePreliminaryType(): SymbolType {
-    const reference = new PlaceholderSymbolType({ name: this.name.text });
+    const reference = new PlaceholderSymbolType({
+      name: this.name.text,
+      rebindingAllowed: true,
+    });
     reference.bind(new IgnoreSymbolType());
     return reference;
   }

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -89,7 +89,16 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
         }));
       }
     }
-
+    if (!this.typeAnnotation.hasValue() && !this.expression.hasValue()) {
+      findings.errors.push(AnalysisError({
+        message:
+          `For each field, you have to at least specify its type or provide a default value.`,
+        beginHighlight: DummyAstNode.fromToken(this.name),
+        endHighlight: None(),
+        messageHighlight:
+          `The type of the field "${this.name.text}" could not be determined.`,
+      }));
+    }
     return findings;
   }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -132,6 +132,7 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
    */
   generateSymbolType(
     placeholderTypes?: Map<string, PlaceholderSymbolType>,
+    includeDefaultValues = false,
   ): SymbolType {
     const structureType = new CompositeSymbolType({
       id: this.name.text,
@@ -141,6 +142,13 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
       const fieldName = field.name.text;
       const fieldType = field.resolveType();
       structureType.fields.set(fieldName, fieldType);
+      if (includeDefaultValues) {
+        field.defaultValue
+          .map((node) => node.evaluate())
+          .then((defaultValue) => {
+            structureType.defaultValues.set(fieldName, defaultValue);
+          });
+      }
     }
     typeTable.setType(this.name.text, structureType);
     return structureType;
@@ -260,6 +268,7 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
     }
     const structureType = this.generateSymbolType(
       placeholderTypes,
+      true,
     );
     typeTable.popScope();
     typeTable.setType(

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -14,7 +14,6 @@ import {
 import { EvaluableAstNode, InterpretableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
-import { SymbolValue } from "../symbol.ts";
 import {
   CompositeSymbolType,
   PlaceholderSymbolType,
@@ -61,7 +60,22 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
   }
 
   analyze(): AnalysisFindings {
-    throw new Error("Method not implemented.");
+    let findings = AnalysisFindings.empty();
+    const typeAnnotationFindings = this.typeAnnotation
+      .map((typeAnnotation) => typeAnnotation.analyze())
+      .unwrapOr(AnalysisFindings.empty());
+    const defaultValueFindings = this.expression
+      .map((defaultValue) => defaultValue.analyze())
+      .unwrapOr(AnalysisFindings.empty());
+    findings = AnalysisFindings.merge(
+      typeAnnotationFindings,
+      defaultValueFindings,
+    );
+    if (findings.isErroneous()) {
+      return findings;
+    }
+
+    return findings;
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -303,17 +303,11 @@ const field = apply(
     opt_sc(starts_with_breaking_whitespace(defaultValue)),
   ),
   ([fieldName, fieldType, defaultValue]) =>
-    // Typescripts type checker is not so smart sometimes.
-    // It needs to be reminded that this is a tuple, not an array.
-    <[
-      Token<TokenKind>,
-      Option<TypeLiteralAstNode>,
-      Option<ExpressionAstNode>,
-    ]> [
-      fieldName,
-      Some(fieldType),
-      Some(defaultValue),
-    ],
+    new FieldAstNode({
+      name: fieldName,
+      typeAnnotation: fieldType,
+      defaultValue: defaultValue,
+    }),
 );
 
 const fieldSeparator = alt(

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -46,10 +46,6 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
     this.expression = Some(params.expression);
   }
 
-  evaluate(): SymbolValue<unknown> {
-    throw new Error("Method not implemented.");
-  }
-
   resolveType(): SymbolType {
     return (this.typeAnnotation as Option<
       TypeLiteralAstNode | ExpressionAstNode

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -150,7 +150,6 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
           });
       }
     }
-    typeTable.setType(this.name.text, structureType);
     return structureType;
   }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -352,6 +352,8 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
       this.name.text,
       incompleteStructureType,
     );
+    const constructor = this.generateConstructorStaticSymbol(incompleteStructureType);
+    analysisTable.setSymbol(this.name.text, constructor);
     const fieldNames: string[] = [];
     // First (preliminary) pass of the analysis without field types set
     let preliminaryFindings = AnalysisFindings.empty();
@@ -395,8 +397,6 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
       this.name.text,
       structureType,
     );
-    const constructor = this.generateConstructorStaticSymbol(structureType);
-    analysisTable.setSymbol(this.name.text, constructor);
     return findings;
   }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -216,14 +216,13 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
       typeTable.setType(placeholerName, placeholderType);
     }
     const fieldNames: string[] = [];
-    for (const [fieldNameToken, fieldTypeNode] of this.fields) {
-      const fieldTypeFindings = fieldTypeNode.analyze();
-      findings = AnalysisFindings.merge(findings, fieldTypeFindings);
-      const fieldName = fieldNameToken.text;
+    for (const field of this.fields) {
+      findings = AnalysisFindings.merge(findings, field.analyze());
+      const fieldName = field.name.text;
       if (fieldNames.includes(fieldName)) {
         findings.errors.push(AnalysisError({
           message: "Fields inside of a structure have to have a unique name.",
-          beginHighlight: DummyAstNode.fromToken(fieldNameToken),
+          beginHighlight: DummyAstNode.fromToken(field.name),
           endHighlight: None(),
           messageHighlight:
             `The field called "${fieldName}" already exists in the structure.`,

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -103,7 +103,16 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
-    throw new Error("Method not implemented.");
+    return [
+      this.name,
+      this.defaultValue
+        .map((value) => value.tokenRange()[1])
+        .unwrapOr(
+          this.typeAnnotation
+            .map((type) => type.tokenRange()[1])
+            .unwrapOr(this.name),
+        ),
+    ];
   }
 }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -260,6 +260,7 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
     );
     let unproblematicPlaceholders: string[] = [];
     for (const placeholder of this.placeholders) {
+      let problematic = false;
       typeTable.findType(placeholder.text)
         .then(() => {
           findings.errors.push(AnalysisError({
@@ -272,8 +273,21 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
           }));
         })
         .onNone(() => {
-          unproblematicPlaceholders.push(placeholder.text);
+          problematic = true;
         });
+      if (placeholder.text === this.name.text) {
+        findings.errors.push(AnalysisError({
+          message:
+            "A placeholder cannot share the same name as its surrounding structure.",
+          beginHighlight: DummyAstNode.fromToken(placeholder),
+          endHighlight: None(),
+          messageHighlight: "",
+        }));
+        problematic = true;
+      }
+      if (!problematic) {
+        unproblematicPlaceholders.push(placeholder.text);
+      }
     }
     const placeholderDuplicates = findDuplicates(
       this.placeholders.map((p) => p.text),

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -256,33 +256,6 @@ export class StructureDefinitonAstNode implements InterpretableAstNode {
   }
 }
 
-class MethodDefinitionAstNode implements EvaluableAstNode {
-  name!: Token<TokenKind>;
-  typeAnnotation!: Option<TypeLiteralAstNode>;
-  function!: FunctionDefinitionAstNode;
-
-  constructor(params: WithOptionalAttributes<MethodDefinitionAstNode>) {
-    Object.assign(this, params);
-    this.typeAnnotation = Some(params.typeAnnotation);
-  }
-
-  evaluate(): SymbolValue<unknown> {
-    throw new Error("Method not implemented.");
-  }
-
-  resolveType(): SymbolType {
-    throw new Error("Method not implemented.");
-  }
-
-  analyze(): AnalysisFindings {
-    throw new Error("Method not implemented.");
-  }
-
-  tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
-    throw new Error("Method not implemented.");
-  }
-}
-
 /* PARSER */
 
 const placeholderNames = kleft(

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -22,9 +22,14 @@ import {
 } from "../type.ts";
 import { findDuplicates, removeAll } from "../util/array.ts";
 import { None } from "../util/monad/option.ts";
-import { kouter, surround_with_breaking_whitespace } from "../util/parser.ts";
+import {
+  kouter,
+  starts_with_breaking_whitespace,
+  surround_with_breaking_whitespace,
+} from "../util/parser.ts";
 import { DummyAstNode } from "../util/snippet.ts";
 import { Attributes } from "../util/type.ts";
+import { functionDefinition } from "./parser_declarations.ts";
 import { typeLiteral, TypeLiteralAstNode } from "./type_literal.ts";
 
 /* AST NODES */
@@ -217,6 +222,13 @@ const fields = kleft(
     fieldSeparator,
   ),
   opt_sc(str(",")),
+);
+
+const method = seq(
+  tok(TokenKind.ident),
+  opt_sc(starts_with_breaking_whitespace(typeLiteral)),
+  surround_with_breaking_whitespace(str<TokenKind>("=")),
+  functionDefinition,
 );
 
 export const structureDefinition = apply(

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -35,6 +35,34 @@ import { typeLiteral, TypeLiteralAstNode } from "./type_literal.ts";
 
 /* AST NODES */
 
+class FieldAstNode implements Partial<EvaluableAstNode> {
+  name!: Token<TokenKind>;
+  typeAnnotation!: Option<TypeLiteralAstNode>;
+  expression!: Option<ExpressionAstNode>;
+
+  constructor(params: WithOptionalAttributes<FieldAstNode>) {
+    Object.assign(this, params);
+    this.typeAnnotation = Some(params.typeAnnotation);
+    this.expression = Some(params.expression);
+  }
+
+  evaluate(): SymbolValue<unknown> {
+    throw new Error("Method not implemented.");
+  }
+
+  resolveType(): SymbolType {
+    throw new Error("Method not implemented.");
+  }
+
+  analyze(): AnalysisFindings {
+    throw new Error("Method not implemented.");
+  }
+
+  tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
+    throw new Error("Method not implemented.");
+  }
+}
+
 export class StructureDefinitonAstNode implements InterpretableAstNode {
   keyword!: Token<TokenKind>;
   placeholders!: Token<TokenKind>[];

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -87,7 +87,7 @@ type HookParameter = {
  * Responsible for creating the runtime symbol for a runtime binding
  * that will end up in the runtime table.
  */
-function createRuntimeBindingRuntimeSymbol(
+export function createRuntimeBindingRuntimeSymbol(
     parameters: HookParameter[],
     returnType: SymbolType,
     hook: (params: Map<string, SymbolValue>) => SymbolValue | void,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -126,7 +126,7 @@ function createRuntimeBindingRuntimeSymbol(
  * Responsible for creating the static symbol for a runtime binding
  * that will end up in the analysis table.
  */
-function createRuntimeBindingStaticSymbol(
+export function createRuntimeBindingStaticSymbol(
     parameters: HookParameter[],
     returnType: SymbolType = nothingType,
 ): StaticSymbol {

--- a/src/type.ts
+++ b/src/type.ts
@@ -365,7 +365,6 @@ export class FunctionSymbolType implements SymbolType {
 export class CompositeSymbolType implements SymbolType {
   id!: string;
   fields!: Map<string, SymbolType>;
-  defaultValues!: Map<string, SymbolValue>;
   placeholders!: Map<string, PlaceholderSymbolType>;
 
   constructor(

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,7 +4,6 @@ import { InternalError } from "./util/error.ts";
 import { globalAutoincrement } from "./util/increment.ts";
 import { None, Option, Some } from "./util/monad/index.ts";
 import { surroundWithIfNonEmpty } from "./util/string.ts";
-import { WithOptionalAttributes } from "./util/type.ts";
 
 type PrimitiveSymbolTypeKind = "Number" | "Boolean" | "String";
 
@@ -555,10 +554,20 @@ export class CompositeSymbolType implements SymbolType {
 export class PlaceholderSymbolType implements SymbolType {
   reference!: Option<SymbolType>;
   name!: string;
+  rebindingAllowed!: boolean;
 
-  constructor(params: WithOptionalAttributes<PlaceholderSymbolType>) {
-    Object.assign(this, params);
-    this.reference = Some(params.reference);
+  constructor({
+    reference,
+    name,
+    rebindingAllowed = false,
+  }: {
+    reference?: SymbolType;
+    name: string;
+    rebindingAllowed?: boolean;
+  }) {
+    this.reference = Some(reference);
+    this.name = name;
+    this.rebindingAllowed = rebindingAllowed;
   }
 
   typeCompatibleWith(
@@ -625,7 +634,7 @@ export class PlaceholderSymbolType implements SymbolType {
   }
 
   bind(to: SymbolType) {
-    if (this.bound()) {
+    if (this.bound() && !this.rebindingAllowed) {
       throw new InternalError(
         "A PlaceholderSymbolType can only be bound to another type once.",
       );

--- a/src/type.ts
+++ b/src/type.ts
@@ -330,18 +330,17 @@ export class CompositeSymbolType implements SymbolType {
   defaultValues!: Map<string, SymbolValue>;
   placeholders!: Map<string, PlaceholderSymbolType>;
 
-  /**
-   * @param fields The key-value pairs of name and type that make up this user defined type.
-   */
   constructor(
     params: {
       id: string;
       fields?: Map<string, SymbolType>;
+      defaultValues?: Map<string, SymbolValue>;
       placeholders?: Map<string, PlaceholderSymbolType>;
     },
   ) {
     params.fields ??= new Map();
     params.placeholders ??= new Map();
+    params.defaultValues ??= new Map();
     Object.assign(this, params);
   }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,3 +1,4 @@
+import { SymbolValue } from "./symbol.ts";
 import { zip } from "./util/array.ts";
 import { InternalError } from "./util/error.ts";
 import { globalAutoincrement } from "./util/increment.ts";
@@ -323,6 +324,9 @@ export class FunctionSymbolType implements SymbolType {
 export class CompositeSymbolType implements SymbolType {
   id!: string;
   fields!: Map<string, SymbolType>;
+  // Default values are ignored during type comparisons.
+  // They are only accessed during instantiation of the type.
+  defaultValues!: Map<string, SymbolValue>;
   placeholders!: Map<string, PlaceholderSymbolType>;
 
   /**

--- a/src/type.ts
+++ b/src/type.ts
@@ -320,12 +320,13 @@ export class FunctionSymbolType implements SymbolType {
  * Two instances of `CompositeSymbolType` are type compatible in case they contain
  * the same amount of field, the fields have the same names,
  * and the types for each field are type compatible themselves.
+ * A `CompositeSymbolType` can contain default values for each of its fields,
+ * which are only used during the instantiation of the type.
+ * Default values are ignored during type comparisons.
  */
 export class CompositeSymbolType implements SymbolType {
   id!: string;
   fields!: Map<string, SymbolType>;
-  // Default values are ignored during type comparisons.
-  // They are only accessed during instantiation of the type.
   defaultValues!: Map<string, SymbolValue>;
   placeholders!: Map<string, PlaceholderSymbolType>;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -130,6 +130,11 @@ export interface SymbolType {
    * Whether this type represents a function type.
    */
   isFunction(): boolean;
+
+  /**
+   * Whether to ignore potential analysis findings that are caused by this type.
+   */
+  ignore(): boolean;
 }
 
 export class FunctionSymbolType implements SymbolType {
@@ -340,6 +345,10 @@ export class FunctionSymbolType implements SymbolType {
   isFunction(): boolean {
     return true;
   }
+
+  ignore(): boolean {
+    return false;
+  }
 }
 
 /**
@@ -549,6 +558,10 @@ export class CompositeSymbolType implements SymbolType {
   isFunction(): boolean {
     return false;
   }
+
+  ignore(): boolean {
+    return false;
+  }
 }
 
 export class PlaceholderSymbolType implements SymbolType {
@@ -673,6 +686,12 @@ export class PlaceholderSymbolType implements SymbolType {
       .map((reference) => reference.isFunction())
       .unwrapOr(false);
   }
+
+  ignore(): boolean {
+    return this.reference
+      .map((reference) => reference.ignore())
+      .unwrapOr(false);
+  }
 }
 
 /**
@@ -737,6 +756,10 @@ export class IgnoreSymbolType implements SymbolType {
   }
 
   isFunction(): boolean {
+    return true;
+  }
+
+  ignore(): boolean {
     return true;
   }
 }
@@ -824,6 +847,10 @@ export class UniqueSymbolType implements SymbolType {
   }
 
   isFunction(): boolean {
+    return false;
+  }
+
+  ignore(): boolean {
     return false;
   }
 }

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -1,0 +1,7 @@
+export function between(
+    number: number,
+    minConstraint: number,
+    maxConstraint: number,
+): boolean {
+    return number >= minConstraint && number <= maxConstraint;
+}


### PR DESCRIPTION
This PR adds support for default values in structures. Example:

```
structure Person {
  name: String,
  age: Number,
  gender = "male",
}

my_person = Person("Steve", 42)
```

As can be seen from the example, the field called `gender` does not need to be initialized in the constructor. In fact, it is currently not possible to set a field in the constructor when that same field has a default value.

Type inference is used to determine the type of a field when it is initialized using a default value. However, it is still possible to add an explicit type annotation. When the type of the default value and the type annotation do not match, an error is generated.

```
structure Person {
  name: String,
  age: Number,
  gender: String = "male",
}
```

This change also allows for an early version of methods to be used. The method is defined as a default parameter. However, the `this` parameter still has to be manually passed to the method. Also, methods cannot be called using the property access syntax yet (`my_person.is_adult()`). Instead, the method has to be bound to a variable, which can then be called.

```
structure Person {
  name: String,
  age: Number,
  is_adult = function(this: Person) -> Boolean {
    return this.age >= 18
  }
}

my_person = Person("Steve", 42)
is_adult = my_person.is_adult
result = is_adult(my_person)
```

Details on the internal implementation:
-  Recursive (self-referential) types are now possible. This enables methods to reference their surrounding type (e.g. in the `this` parameter).
- Types are not instantiated using dedicated logic anymore. Rather, during type definition, a constructor function with the same name as the type is registered. The constructor is invoked like any other function and returns a new instance of the type.