### PR TITLE
Fix property access whitespace

### DIFF
--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -12,7 +12,10 @@ import { CompositeSymbolType, SymbolType } from "../type.ts";
 import { InternalError } from "../util/error.ts";
 import { None } from "../util/monad/index.ts";
 import { Attributes } from "../util/type.ts";
-import { ends_with_breaking_whitespace } from "../util/parser.ts";
+import {
+  ends_with_breaking_whitespace,
+  starts_with_breaking_whitespace,
+} from "../util/parser.ts";
 
 /* AST NODES */
 
@@ -151,7 +154,11 @@ const referenceExpression = apply(
 export const symbolExpression = apply(
   seq(
     referenceExpression,
-    rep_sc(propertyAccess),
+    rep_sc(
+      starts_with_breaking_whitespace(
+        propertyAccess,
+      ),
+    ),
   ),
   ([rootSymbol, propertyAccesses]) => {
     return propertyAccesses.reduce(

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -12,6 +12,7 @@ import { CompositeSymbolType, SymbolType } from "../type.ts";
 import { InternalError } from "../util/error.ts";
 import { None } from "../util/monad/index.ts";
 import { Attributes } from "../util/type.ts";
+import { ends_with_breaking_whitespace } from "../util/parser.ts";
 
 /* AST NODES */
 
@@ -138,7 +139,7 @@ class PropertyAccessAstNode implements EvaluableAstNode {
 /* PARSER */
 
 const propertyAccess = kright(
-  str<TokenKind>("."),
+  ends_with_breaking_whitespace(str<TokenKind>(".")),
   tok(TokenKind.ident),
 );
 


### PR DESCRIPTION
This PR addresses the fact that placing (breaking) whitespace in the property access syntax was not accepted by the parser.
In the following example, the field called `name` of type `A` is accessed via the dot notation. The parser now allows breaking whitespace in the expression.
```
structure A {
  name: String
}
a = A("Steve")
b = a

.

name

print(b)
```

Output:

```
Steve
```