### PR TITLE
Allow methods to be called directly

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -40,7 +40,7 @@ export interface EvaluableAstNode<R = SymbolValue<unknown>, S = SymbolType>
   /**
    * Returns the corresponding `SymbolType` of the evaluated result.
    * Before this method can be called, it has to be made sure
-   * that `analyze` is called first on the AST node and its result is inspected.
+   * that `analyze` is called first on the AST node and its result is not erroneous.
    * Static analysis should catch any errors in regards to type resolving (e.g. the type does not exist).
    * Even though implementations of `resolveType` can assume that `analyze` has been called already,
    * an `InternalError` should still be thrown in case `analyze` has not been called and type resolving fails.
@@ -51,6 +51,8 @@ export interface EvaluableAstNode<R = SymbolValue<unknown>, S = SymbolType>
    * Returns symbol flags associated with the evaluated symbol.
    * Flags are usually stored in the symbol table. In case process of evaluating the AST node
    * does not involve querying the symbol table, the returned flags will likely be empty.
+   * Before this method can be called, it has to be made sure
+   * that `analyze` is called first on the AST node and its result is not erroneous.
    */
   resolveFlags(): Map<keyof SymbolFlags, boolean>;
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -2,7 +2,7 @@ import { Token } from "typescript-parsec";
 import { StatementsAstNode } from "./features/statement.ts";
 import { AnalysisFindings } from "./finding.ts";
 import { TokenKind } from "./lexer.ts";
-import { SymbolValue } from "./symbol.ts";
+import { SymbolFlags, SymbolValue } from "./symbol.ts";
 import { SymbolType } from "./type.ts";
 
 /**
@@ -30,7 +30,8 @@ export interface AstNode {
  * This type of AST node is primarily used for expressions, which evaluate to a result.
  * In rare cases, the execution can produce side effects, however most of the time, the result should just be returned.
  */
-export interface EvaluableAstNode<R = SymbolValue<unknown>, S = SymbolType> extends AstNode {
+export interface EvaluableAstNode<R = SymbolValue<unknown>, S = SymbolType>
+  extends AstNode {
   /**
    * Executes the content of the AST node while yielding a result.
    */
@@ -45,6 +46,13 @@ export interface EvaluableAstNode<R = SymbolValue<unknown>, S = SymbolType> exte
    * an `InternalError` should still be thrown in case `analyze` has not been called and type resolving fails.
    */
   resolveType(): S;
+
+  /**
+   * Returns symbol flags associated with the evaluated symbol.
+   * Flags are usually stored in the symbol table. In case process of evaluating the AST node
+   * does not involve querying the symbol table, the returned flags will likely be empty.
+   */
+  resolveFlags(): Map<keyof SymbolFlags, boolean>;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import * as interpreter from "./main.ts";
 import { VirtualTextFile } from "./streams.ts";
+import { InternalError, RuntimeError } from "./util/error.ts";
 import { onReadLine } from "./util/file.ts";
 import * as logger from "./util/logger.ts";
 import { Loglevel, updateLoggerConfig } from "./util/logger.ts";
@@ -39,7 +40,9 @@ function run(input_file_path: string) {
     findings.errors.forEach(logger.error);
     findings.warnings.forEach(logger.warning);
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof InternalError || error instanceof RuntimeError) {
+      logger.error(error.toString());
+    } else if (error instanceof Error) {
       logger.error(`${error.message}\n${error.stack}`);
     } else {
       logger.error("Unrecognized error");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,11 @@ function run(input_file_path: string) {
     findings.errors.forEach(logger.error);
     findings.warnings.forEach(logger.warning);
   } catch (error) {
-    logger.error(error);
+    if (error instanceof Error) {
+      logger.error(`${error.message}\n${error.stack}`);
+    } else {
+      logger.error("Unrecognized error");
+    }
   }
   stdinReadSubscription.cancel();
   stdout.close();

--- a/src/features/expression.ts
+++ b/src/features/expression.ts
@@ -2,7 +2,7 @@ import { apply, Parser, Token } from "typescript-parsec";
 import { EvaluableAstNode, InterpretableAstNode } from "../ast.ts";
 import { AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
-import { SymbolValue } from "../symbol.ts";
+import { SymbolFlags, SymbolValue } from "../symbol.ts";
 import { SymbolType } from "../type.ts";
 import { alt_sc_var } from "../util/parser.ts";
 import { Attributes } from "../util/type.ts";
@@ -39,6 +39,10 @@ export class ExpressionAstNode
 
   resolveType(): SymbolType {
     return this.child.resolveType();
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return this.child.resolveFlags();
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/expression.ts
+++ b/src/features/expression.ts
@@ -1,9 +1,10 @@
-import { alt_sc, apply, Token } from "typescript-parsec";
+import { apply, Parser, Token } from "typescript-parsec";
 import { EvaluableAstNode, InterpretableAstNode } from "../ast.ts";
 import { AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
 import { SymbolValue } from "../symbol.ts";
 import { SymbolType } from "../type.ts";
+import { alt_sc_var } from "../util/parser.ts";
 import { Attributes } from "../util/type.ts";
 import { booleanExpression } from "./boolean_expression.ts";
 import { numericExpression } from "./numeric_expression.ts";
@@ -47,15 +48,42 @@ export class ExpressionAstNode
 
 /* PARSER */
 
-export const expression = apply(
-  alt_sc(
-    invocation,
-    booleanExpression,
-    numericExpression,
-    complexStringLiteral,
-    symbolExpression,
-    functionDefinition,
-  ),
-  (expression: EvaluableAstNode) =>
-    new ExpressionAstNode({ child: expression }),
-);
+type ExpressionOptions = {
+  includeInvocation?: boolean;
+  includeBooleanExpression?: boolean;
+  includeNumericExpression?: boolean;
+  includeComplexStringLiteral?: boolean;
+  includeSymbolExpression?: boolean;
+  includeFunctionDefinition?: boolean;
+};
+
+/**
+ * Builds a parser for expressions, but allows the
+ * user to disable certain kinds of expressions.
+ */
+export function configureExpression({
+  includeInvocation = true,
+  includeBooleanExpression = true,
+  includeNumericExpression = true,
+  includeComplexStringLiteral = true,
+  includeSymbolExpression = true,
+  includeFunctionDefinition = true,
+}: ExpressionOptions): Parser<TokenKind, ExpressionAstNode> {
+  const enabledParsers = (<[Parser<TokenKind, EvaluableAstNode>, boolean][]> [
+    [invocation, includeInvocation],
+    [booleanExpression, includeBooleanExpression],
+    [numericExpression, includeNumericExpression],
+    [complexStringLiteral, includeComplexStringLiteral],
+    [symbolExpression, includeSymbolExpression],
+    [functionDefinition, includeFunctionDefinition],
+  ]).filter(([_, enabled]) => enabled)
+    .map(([parser, _]) => parser);
+
+  return apply(
+    alt_sc_var(...enabledParsers),
+    (expression: EvaluableAstNode) =>
+      new ExpressionAstNode({ child: expression }),
+  );
+}
+
+export const expression = configureExpression({});

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -22,6 +22,7 @@ import {
   analysisTable,
   FunctionSymbolValue,
   StaticSymbol,
+  SymbolFlags,
   SymbolValue,
 } from "../symbol.ts";
 import {
@@ -325,6 +326,10 @@ export class FunctionDefinitionAstNode implements EvaluableAstNode {
       placeholders: placeholders,
       returnType: returnType,
     });
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -21,6 +21,7 @@ import {
   FunctionSymbolValue,
   RuntimeSymbol,
   runtimeTable,
+  SymbolFlags,
   SymbolValue,
 } from "../symbol.ts";
 import {
@@ -301,6 +302,10 @@ export class InvocationAstNode implements EvaluableAstNode {
       placeholder.bind(suppliedType.unwrap());
     }
     return functionType.returnType;
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -155,6 +155,13 @@ export class InvocationAstNode implements EvaluableAstNode {
         (previous, current) => AnalysisFindings.merge(previous, current),
         AnalysisFindings.empty(),
       );
+    findings = AnalysisFindings.merge(
+      findings,
+      this.symbol.analyze(),
+    );
+    if (findings.isErroneous()) {
+      return findings;
+    }
     const calledSymbol = analysisTable.findSymbol(this.name.text);
     const [isFunction, symbolExists, ignoreFunction] = calledSymbol
       .map(([symbol, _flags]) => [

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -80,14 +80,9 @@ export class InvocationAstNode implements EvaluableAstNode {
     const parent = this.parent.unwrap();
     const parentType = parent.resolveType().peel();
     const memberType = this.symbol.resolveType().peel() as FunctionSymbolType;
-    const memberInstance = this.symbol.evaluate() as FunctionSymbolValue;
-    const memberParameters = memberInstance.parameterNames;
     const memberParameterTypes = memberType.parameterTypes;
-    const nameMatch = memberParameters.length >= 1 &&
-      memberParameters[0] == "this";
-    const typeMatch = memberParameterTypes.length >= 1 &&
+    return memberParameterTypes.length >= 1 &&
       memberParameterTypes[0].typeCompatibleWith(parentType);
-    return nameMatch && typeMatch;
   }
 
   analyzePlaceholders(

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -42,7 +42,7 @@ import { invocation } from "./parser_declarations.ts";
 /* AST NODES */
 
 export class InvocationAstNode implements EvaluableAstNode {
-  name!: Token<TokenKind>;
+  symbol!: EvaluableAstNode;
   parameters!: ExpressionAstNode[];
   placeholders!: Token<TokenKind>[];
   openParenthesis!: Token<TokenKind>;
@@ -294,7 +294,7 @@ const parameters = list_sc(
 
 invocation.setPattern(apply(
   seq(
-    tok(TokenKind.ident),
+    expression,
     opt_sc(starts_with_breaking_whitespace(placeholders)),
     surround_with_breaking_whitespace(str("(")),
     opt(parameters),

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -301,7 +301,12 @@ export class InvocationAstNode implements EvaluableAstNode {
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
-    return [this.name, this.closingParenthesis];
+    return [
+      this.parent
+        .map((parent) => parent.tokenRange()[0])
+        .unwrapOr(this.symbol.tokenRange()[0]),
+      this.closingParenthesis,
+    ];
   }
 }
 

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -217,16 +217,16 @@ export class InvocationAstNode implements EvaluableAstNode {
         messageHighlight: "",
       }));
     }
-    if (ignoreFunction) {
+    if (ignoreFunction || findings.isErroneous()) {
       return findings;
     }
-    if (isFunction && !isMethod && !findings.isErroneous()) {
+    if (isFunction && !isMethod) {
       findings = AnalysisFindings.merge(
         findings,
         this.analyzeFunctionInvocation(calledType as FunctionSymbolType),
       );
     }
-    if (isMethod && !findings.isErroneous()) {
+    if (isMethod) {
       findings = AnalysisFindings.merge(
         findings,
         this.analyzeMethod(calledType as FunctionSymbolType),

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -285,7 +285,9 @@ export class InvocationAstNode implements EvaluableAstNode {
       const parentInstance = this.parent
         .map((parent) => parent.evaluate())
         .unwrapOr(nothingInstance);
-      defaultParameters.set("this", parentInstance);
+      const thisParameterName =
+        (calledSymbol as FunctionSymbolValue).parameterNames[0];
+      defaultParameters.set(thisParameterName, parentInstance);
     }
     const result = this.evaluateFunction(
       calledSymbol as FunctionSymbolValue,

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -378,6 +378,7 @@ const customExpression: Parser<TokenKind, [
   EvaluableAstNode | undefined,
   EvaluableAstNode,
 ]> = alt_sc(
+  memberAccess,
   apply(
     configureExpression({
       includeInvocation: false,
@@ -385,7 +386,6 @@ const customExpression: Parser<TokenKind, [
     }),
     (result) => [undefined, result],
   ),
-  memberAccess,
 );
 
 invocation.setPattern(apply(

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -202,7 +202,7 @@ export class InvocationAstNode implements EvaluableAstNode {
     const calledType = this.symbol.resolveType().peel();
     const isFunction = calledType.isFunction();
     const ignoreFunction = calledType.ignore();
-    const isMethod = isFunction && this.isMethod();
+    const isMethod = isFunction && (!ignoreFunction) && this.isMethod();
     if (!isFunction) {
       findings.errors.push(AnalysisError({
         message:

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -71,7 +71,7 @@ export class InvocationAstNode implements EvaluableAstNode {
   /**
    * Determines whether the called expression is a method or not.
    * Can only safely be called after static analysis has successfully
-   * been performed on the parent and member (symbol) AST nodes.
+   * been performed on the member (symbol) AST nodes.
    */
   isMethod(): boolean {
     const isMember = this.parent.hasValue();

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -232,22 +232,28 @@ export class InvocationAstNode implements EvaluableAstNode {
 
   evaluateFunction(
     functionSymbolValue: FunctionSymbolValue,
-    additionalParameters: Map<string, SymbolValue> = new Map(),
+    defaultParameters: Map<string, SymbolValue> = new Map(),
   ): SymbolValue<unknown> {
     runtimeTable.pushScope();
     const parameterNames = functionSymbolValue.parameterNames;
-    for (let index = 0; index < this.parameters.length; index += 1) {
+    let offset = 0;
+    for (
+      let index = 0;
+      index < functionSymbolValue.parameterNames.length;
+      index += 1
+    ) {
       const parameterName = parameterNames[index];
-      const symbolValue = this.parameters[index].evaluate();
-      runtimeTable.setSymbol(
-        parameterName,
-        new RuntimeSymbol({
-          value: symbolValue,
-        }),
-      );
-    }
-    for (const parameter of additionalParameters.entries()) {
-      const [parameterName, symbolValue] = parameter;
+      if (defaultParameters.has(parameterName)) {
+        offset += 1;
+        runtimeTable.setSymbol(
+          parameterName,
+          new RuntimeSymbol({
+            value: defaultParameters.get(parameterName)!,
+          }),
+        );
+        continue;
+      }
+      const symbolValue = this.parameters[index - offset].evaluate();
       runtimeTable.setSymbol(
         parameterName,
         new RuntimeSymbol({
@@ -274,16 +280,16 @@ export class InvocationAstNode implements EvaluableAstNode {
       // grant the invocation access to the runtime
       runtimeTable.ignoreRuntimeBindings = false;
     }
-    const additionalParameters = new Map<string, SymbolValue>();
+    const defaultParameters = new Map<string, SymbolValue>();
     if (this.isMethod()) {
       const parentInstance = this.parent
         .map((parent) => parent.evaluate())
         .unwrapOr(nothingInstance);
-      additionalParameters.set("this", parentInstance);
+      defaultParameters.set("this", parentInstance);
     }
     const result = this.evaluateFunction(
       calledSymbol as FunctionSymbolValue,
-      additionalParameters,
+      defaultParameters,
     );
     runtimeTable.ignoreRuntimeBindings = true;
     return result;

--- a/src/features/numeric_expression.ts
+++ b/src/features/numeric_expression.ts
@@ -12,7 +12,7 @@ import {
 import { EvaluableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
-import { NumericSymbolValue, SymbolValue } from "../symbol.ts";
+import { NumericSymbolValue, SymbolFlags, SymbolValue } from "../symbol.ts";
 import { CompositeSymbolType, SymbolType } from "../type.ts";
 import { InternalError, RuntimeError } from "../util/error.ts";
 import { memoize } from "../util/memoize.ts";
@@ -47,6 +47,10 @@ class NumericLiteralAstNode implements NumericExpressionAstNode {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.token, this.token];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 
@@ -87,6 +91,10 @@ class UnaryNumericExpressionAstNode implements NumericExpressionAstNode {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.operatorToken, this.child.tokenRange()[1]];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 
@@ -163,6 +171,10 @@ class BinaryNumericExpressionAstNode implements NumericExpressionAstNode {
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.lhs.tokenRange()[0], this.rhs.tokenRange()[1]];
   }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
+  }
 }
 
 /* Ambiguously typed expression */
@@ -200,6 +212,10 @@ class AmbiguouslyTypedExpressionAstNode implements NumericExpressionAstNode {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return this.child.tokenRange();
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 

--- a/src/features/string.ts
+++ b/src/features/string.ts
@@ -115,20 +115,26 @@ export class StringInterpolationAstNode implements EvaluableAstNode {
       "Number",
       "String",
     ];
-    const expressionIsFundamental = fundamentalTypeIds.map(
-      (id) => {
-        return this.expression
-          .map((node) => node.resolveType())
+    const expressionType = this.expression
+      .map((node) => node.resolveType());
+    const expressionIsFundamental = fundamentalTypeIds
+      .map((id) =>
+        expressionType
           .map((type) => type.isFundamental(id))
-          .unwrapOr(true);
-      },
-    );
+          .unwrapOr(true)
+      )
+      .some((isFundamental) => isFundamental);
     if (!expressionIsFundamental) {
       findings.errors.push(
         AnalysisError({
           message: "Only fundamental types can be interpolated in a string.",
           beginHighlight: this.expression.unwrap(),
           endHighlight: None(),
+          messageHighlight: `Type "${
+            expressionType
+              .map((type) => type.displayName())
+              .unwrapOr("")
+          }" cannot be used in a string interpolation.`,
         }),
       );
     }

--- a/src/features/string.ts
+++ b/src/features/string.ts
@@ -15,7 +15,8 @@ import {
   AnalysisWarning,
 } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
-import { StringSymbolValue } from "../symbol.ts";
+import { Option } from "../main.ts";
+import { StringSymbolValue, SymbolFlags } from "../symbol.ts";
 import {
   CompositeSymbolType,
   FundamentalSymbolTypeKind,
@@ -24,12 +25,11 @@ import {
 import { InternalError } from "../util/error.ts";
 import { memoize } from "../util/memoize.ts";
 import { None, Some } from "../util/monad/option.ts";
+import { rep_at_least_once_sc } from "../util/parser.ts";
+import { DummyAstNode } from "../util/snippet.ts";
 import { Attributes, WithOptionalAttributes } from "../util/type.ts";
 import { expression } from "./expression.ts";
 import { complexStringLiteral } from "./parser_declarations.ts";
-import { rep_at_least_once_sc } from "../util/parser.ts";
-import { Option } from "../main.ts";
-import { DummyAstNode } from "../util/snippet.ts";
 
 /* AST NODES */
 
@@ -63,6 +63,10 @@ class StringContentsAstNode implements EvaluableAstNode {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.contents[0], this.contents.toReversed()[0]];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 
@@ -134,6 +138,10 @@ export class StringInterpolationAstNode implements EvaluableAstNode {
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.beginDelimiter, this.endDelimiter];
   }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
+  }
 }
 
 export class ComplexStringAstNode implements EvaluableAstNode {
@@ -164,6 +172,10 @@ export class ComplexStringAstNode implements EvaluableAstNode {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.openingQuotation, this.closingQuotation];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -21,6 +21,7 @@ import {
   RuntimeSymbol,
   runtimeTable,
   StaticSymbol,
+  SymbolFlags,
   SymbolValue,
 } from "../symbol.ts";
 import {
@@ -143,6 +144,10 @@ class FieldAstNode implements Partial<EvaluableAstNode> {
             .unwrapOr(this.name),
         ),
     ];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -6,16 +6,17 @@ import {
   analysisTable,
   CompositeSymbolValue,
   runtimeTable,
+  SymbolFlags,
   SymbolValue,
 } from "../symbol.ts";
 import { CompositeSymbolType, SymbolType } from "../type.ts";
 import { InternalError } from "../util/error.ts";
 import { None } from "../util/monad/index.ts";
-import { Attributes } from "../util/type.ts";
 import {
   ends_with_breaking_whitespace,
   starts_with_breaking_whitespace,
 } from "../util/parser.ts";
+import { Attributes } from "../util/type.ts";
 
 /* AST NODES */
 
@@ -66,6 +67,15 @@ export class ReferenceExpressionAstNode implements EvaluableAstNode {
           "This should have been caught by static analysis.",
         ),
       );
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return analysisTable
+      .findSymbol(this.identifierToken.text)
+      .map(([_symbol, flags]) =>
+        new Map(Object.entries(flags)) as Map<keyof SymbolFlags, boolean>
+      )
+      .unwrapOr(new Map());
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
@@ -132,6 +142,10 @@ export class PropertyAccessAstNode implements EvaluableAstNode {
       );
     }
     return accessedType;
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {

--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -73,7 +73,7 @@ export class ReferenceExpressionAstNode implements EvaluableAstNode {
   }
 }
 
-class PropertyAccessAstNode implements EvaluableAstNode {
+export class PropertyAccessAstNode implements EvaluableAstNode {
   identifierToken!: Token<TokenKind>;
   parent!: EvaluableAstNode;
 
@@ -141,12 +141,12 @@ class PropertyAccessAstNode implements EvaluableAstNode {
 
 /* PARSER */
 
-const propertyAccess = kright(
+export const propertyAccess = kright(
   ends_with_breaking_whitespace(str<TokenKind>(".")),
   tok(TokenKind.ident),
 );
 
-const referenceExpression = apply(
+export const referenceExpression = apply(
   tok(TokenKind.ident),
   (identifier) => new ReferenceExpressionAstNode(identifier),
 );

--- a/src/features/type_literal.ts
+++ b/src/features/type_literal.ts
@@ -13,6 +13,7 @@ import {
 import { EvaluableAstNode } from "../ast.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
+import { SymbolFlags } from "../symbol.ts";
 import {
   CompositeSymbolType,
   FunctionSymbolType,
@@ -79,6 +80,10 @@ export class FunctionTypeLiteralAstNode implements Partial<EvaluableAstNode> {
           this.closingParenthesis.unwrapOr(this.name),
         ),
     ];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 
@@ -163,6 +168,10 @@ export class CompositeTypeLiteralAstNode implements Partial<EvaluableAstNode> {
 
   tokenRange(): [Token<TokenKind>, Token<TokenKind>] {
     return [this.name, this.closingBracket.unwrapOr(this.name)];
+  }
+
+  resolveFlags(): Map<keyof SymbolFlags, boolean> {
+    return new Map();
   }
 }
 

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -130,7 +130,7 @@ export class CompositeSymbolValue
 
 // Symbol Table
 
-type SymbolFlags = {
+export type SymbolFlags = {
   readonly: boolean;
   /**
    * Whether the symbol is part of the standard library.

--- a/src/type.ts
+++ b/src/type.ts
@@ -296,6 +296,12 @@ export class FunctionSymbolType implements SymbolType {
     if (memo.has(this)) {
       return memo.get(this) as FunctionSymbolType;
     }
+    const copy = new FunctionSymbolType({
+      parameterTypes: [],
+      returnType: this.returnType,
+      placeholders: new Map(),
+    });
+    memo.set(this, copy);
     const originalPlaceholders: SymbolType[] = Array.from(
       this.placeholders.values(),
     );
@@ -329,12 +335,9 @@ export class FunctionSymbolType implements SymbolType {
         forkedPlaceholders.set(name, type.fork(memo) as PlaceholderSymbolType);
       }
     }
-    const copy = new FunctionSymbolType({
-      parameterTypes: forkedParameters,
-      placeholders: forkedPlaceholders,
-      returnType: forkedReturnType,
-    });
-    memo.set(this, copy);
+    copy.parameterTypes = forkedParameters;
+    copy.placeholders = forkedPlaceholders;
+    copy.returnType = forkedReturnType;
     return copy;
   }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -166,6 +166,9 @@ export class FunctionSymbolType implements SymbolType {
     if (!memo.has(this)) {
       memo.set(this, new Set());
     }
+    if (!memo.has(other)) {
+      memo.set(other, new Set());
+    }
     memo.get(this)!.add(other);
     if (
       other instanceof PlaceholderSymbolType ||
@@ -173,13 +176,19 @@ export class FunctionSymbolType implements SymbolType {
     ) {
       return other.typeCompatibleWith(this, mismatchHandler, memo);
     }
-    // only fork types if no placeholders need to be assumed
+    // only fork types if placeholders need to be assumed
     let self = this as FunctionSymbolType;
     if (!self.complete()) {
+      const originalSelf = self;
       self = self.fork();
+      memo.set(self, memo.get(originalSelf)!);
     }
     if (!other.complete()) {
+      const originalOther = other;
       other = other.fork();
+      memo.set(other, memo.get(originalOther)!);
+      memo.get(other)!.add(self);
+      memo.get(self)!.add(other);
     }
     // trivial case
     if (!(other instanceof FunctionSymbolType)) {


### PR DESCRIPTION
This PR adds an ergonomic syntax to invoke methods using the dot-notation familiar from many C-style languages.

Example:
```
structure Person {
  name: String,
  age: Number,
  introduce = function(this: Person) {
    print("I'm ${this.name} and I'm ${this.age} years old.")
  },
}

steve = Person("Steve", 42)
steve.introduce()
```
Output:
```
I'm Steve and I'm 42 years old.
```

The language automatically passes the `this` parameter to methods when they are called. In fact, it is not even possible to manually pass the `this` parameter during invocation. A method is recognized by the fact that it is a function, a member of another type, and its first parameter is of its surrounding structure's type. Calling the first parameter `this` is only a convention (and therefore encouraged), but not required.
