### PR TITLE
Fix error with type exports

### DIFF
--- a/src/features/assignment.ts
+++ b/src/features/assignment.ts
@@ -3,6 +3,7 @@ import {
   apply,
   kright,
   opt_sc,
+  Parser,
   seq,
   str,
   tok,
@@ -253,7 +254,7 @@ const propertyWrite = apply(
     }),
 );
 
-export const assignment = alt_sc(
+export const assignment: Parser<TokenKind, AssignmentAstNode> = alt_sc(
   variableAssignment,
   propertyWrite,
 );


### PR DESCRIPTION
This PR addresses a small error encountered by the type checker. Assignments can either be variable or property assignments. However, only the AST node for the variable assignment was exported.