### PR TITLE
Add the ability to immediately halt execution (panic)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import * as interpreter from "./main.ts";
 import { VirtualTextFile } from "./streams.ts";
-import { InternalError, RuntimeError } from "./util/error.ts";
+import { InternalError, PanicError, RuntimeError } from "./util/error.ts";
 import { onReadLine } from "./util/file.ts";
 import * as logger from "./util/logger.ts";
 import { Loglevel, updateLoggerConfig } from "./util/logger.ts";
@@ -40,7 +40,11 @@ function run(input_file_path: string) {
     findings.errors.forEach(logger.error);
     findings.warnings.forEach(logger.warning);
   } catch (error) {
-    if (error instanceof InternalError || error instanceof RuntimeError) {
+    if (
+      error instanceof InternalError ||
+      error instanceof RuntimeError ||
+      error instanceof PanicError
+    ) {
       logger.error(error.toString());
     } else if (error instanceof Error) {
       logger.error(`${error.message}\n${error.stack}`);

--- a/src/features/invocation.ts
+++ b/src/features/invocation.ts
@@ -267,6 +267,8 @@ export class InvocationAstNode implements EvaluableAstNode {
     } catch (exception) {
       if (exception instanceof ReturnValueContainer) {
         returnValue = exception.value;
+      } else {
+        throw exception;
       }
     }
     runtimeTable.popScope();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,7 +20,7 @@ import {
     PlaceholderSymbolType,
     SymbolType,
 } from "./type.ts";
-import { InternalError } from "./util/error.ts";
+import { InternalError, PanicError } from "./util/error.ts";
 import { nothingInstance, nothingType } from "./util/type.ts";
 
 /**
@@ -227,7 +227,7 @@ export function injectRuntimeBindings(
         nothingType,
         (params) => {
             const reason = params.get("reason")!.value as string;
-            throw new InternalError(reason);
+            throw new PanicError(reason);
         },
         onlyAnalysis,
     );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -14,7 +14,12 @@ import {
     StringSymbolValue,
     SymbolValue,
 } from "./symbol.ts";
-import { CompositeSymbolType, FunctionSymbolType, PlaceholderSymbolType, SymbolType } from "./type.ts";
+import {
+    CompositeSymbolType,
+    FunctionSymbolType,
+    PlaceholderSymbolType,
+    SymbolType,
+} from "./type.ts";
 import { InternalError } from "./util/error.ts";
 import { nothingInstance, nothingType } from "./util/type.ts";
 
@@ -209,6 +214,20 @@ export function injectRuntimeBindings(
         (params) => {
             const message = params.get("message")!.value as string;
             stdout?.writeChunk(message);
+        },
+        onlyAnalysis,
+    );
+
+    createRuntimeBinding(
+        "runtime_panic",
+        [{
+            name: "reason",
+            symbolType: new CompositeSymbolType({ id: "String" }),
+        }],
+        nothingType,
+        (params) => {
+            const reason = params.get("reason")!.value as string;
+            throw new InternalError(reason);
         },
         onlyAnalysis,
     );

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -40,13 +40,16 @@ export class InternalError extends Error implements AppError {
    * @param message A concise summary of the error.
    * @param extendedMessage Additional information about the error.
    */
-  constructor(public message: string, public extendedMessage: string = "") {
+  constructor(
+    public override message: string,
+    public extendedMessage: string = "",
+  ) {
     super(concatLines(message, extendedMessage));
     this.message = message;
     this.extendedMessage = extendedMessage;
   }
 
-  toString(): string {
+  override toString(): string {
     return toMultiline(
       "INTERNAL ERROR: The language/interpreter reached an internal state which does not allow it to continue running.",
       "This error is not the result of the users input but an issue with the language itself and needs to be fixed.",
@@ -74,7 +77,7 @@ export function UnresolvableSymbolTypeError(): InternalError {
  */
 export class RuntimeError extends Error implements AppError {
   include!: [AstNode, AstNode] | [AstNode];
-  message!: string;
+  override message!: string;
   highlight: Option<[AstNode, AstNode] | [AstNode]>;
   highlightMessage: Option<string>;
 
@@ -96,7 +99,7 @@ export class RuntimeError extends Error implements AppError {
     this.highlightMessage = Some(params.highlightMessage);
   }
 
-  toString(): string {
+  override toString(): string {
     return toMultiline(
       this.message,
       createSnippet(

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -119,3 +119,26 @@ export class RuntimeError extends Error implements AppError {
     );
   }
 }
+
+/**
+ * Similar to `RuntimeError`, but features a simpler interface and does not produce a snippet.
+ * A `PanicError` is an unrecoverable error that is the result of the users input.
+ * It represents expected behavior and is not the result of erroneous internal behavior of the interpreter.
+ * Throwing a `PanicError` is supposed to terminate the execution of the interpreter.
+ */
+export class PanicError extends Error implements AppError {
+  constructor(
+    public reason: string,
+    public extendedMessage: string = "",
+  ) {
+    super(reason);
+  }
+
+  override toString(): string {
+    const header =
+      "The execution of the program was halted because an illegal operation was attempted:";
+    return `${header} ${this.reason}${
+      this.extendedMessage ? " " : ""
+    }${this.extendedMessage}`;
+  }
+}


### PR DESCRIPTION
This PR adds the ability for the stdlib to panic. `panic` is a runtime binding that can only be called from the stdlib. As a result of calling panic, execution of the interpreter is immediately halted. The user is informed that an unrecoverable error has occured, follwed by the reason for the panic. The reason is specified when `panic` is called.