### PR TITLE
Provide a rudimentarty stdlib

### DIFF
--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -380,6 +380,9 @@ export class ReturnStatementAstNode implements InterpretableAstNode {
     const findings = this.expression
       .map((node) => node.analyze())
       .unwrapOr(AnalysisFindings.empty());
+    if (findings.isErroneous()) {
+      return findings;
+    }
     const savedReturnType = typeTable.findReturnType();
     if (savedReturnType.kind === "none") {
       findings.errors.push(AnalysisError({

--- a/src/features/function.ts
+++ b/src/features/function.ts
@@ -124,7 +124,7 @@ export class FunctionDefinitionAstNode implements EvaluableAstNode {
     }
     const returnType = this.returnType
       .map((literal) => literal.resolveType())
-      .unwrapOr(nothingType);
+      .unwrapOr(nothingType());
     typeTable.popScope();
     return new FunctionSymbolValue({
       parameterTypes: parameterTypes,
@@ -288,9 +288,9 @@ export class FunctionDefinitionAstNode implements EvaluableAstNode {
     returnTypeAnalysis.then((findings) => {
       const returnType = this.returnType
         .map((literal) => literal.resolveType())
-        .unwrapOr(nothingType);
+        .unwrapOr(nothingType());
       typeTable.setReturnType(returnType);
-      if (!returnType.typeCompatibleWith(nothingType)) {
+      if (!returnType.typeCompatibleWith(nothingType())) {
         findings = AnalysisFindings.merge(
           findings,
           this.analyzeReturnPlacements(),
@@ -319,7 +319,7 @@ export class FunctionDefinitionAstNode implements EvaluableAstNode {
     );
     const returnType = this.returnType
       .map((literal) => literal.resolveType())
-      .unwrapOr(nothingType);
+      .unwrapOr(nothingType());
     typeTable.popScope();
     return new FunctionSymbolType({
       parameterTypes: parameterTypes,
@@ -401,7 +401,7 @@ export class ReturnStatementAstNode implements InterpretableAstNode {
         messageHighlight: messageHighlight ?? "",
       });
     const returnValueRequired = !supposedReturnType.typeCompatibleWith(
-      nothingType,
+      nothingType(),
     );
     const returnStatementEmpty = actualReturnType.kind === "none";
     if (returnValueRequired && returnStatementEmpty) {

--- a/src/features/type_definition.ts
+++ b/src/features/type_definition.ts
@@ -427,7 +427,10 @@ export class TypeDefinitionAstNode implements InterpretableAstNode {
     let findings = AnalysisFindings.empty();
     typeTable.findType(this.name.text)
       .then(([_type, flags]) => {
-        if (flags.readonly) {
+        if (!flags.readonly) {
+          return;
+        }
+        if (flags.stdlib) {
           findings.errors.push(AnalysisError({
             message:
               "This name cannot be used because it is part of the language.",

--- a/src/features/type_definition.ts
+++ b/src/features/type_definition.ts
@@ -570,6 +570,7 @@ export class TypeDefinitionAstNode implements InterpretableAstNode {
       incompletedefinitionType,
       unproblematicPlaceholderTypes,
     );
+    analysisTable.pushScope();
     analysisTable.setSymbol(
       this.name.text,
       mockConstructor,
@@ -621,6 +622,7 @@ export class TypeDefinitionAstNode implements InterpretableAstNode {
       this.name.text,
       definitionType,
     );
+    analysisTable.popScope();
     analysisTable.setSymbol(this.name.text, constructor);
     return findings;
   }

--- a/src/features/type_literal.ts
+++ b/src/features/type_literal.ts
@@ -53,7 +53,7 @@ export class FunctionTypeLiteralAstNode implements Partial<EvaluableAstNode> {
       parameter.resolveType()
     );
     const returnType = this.returnType.map((node) => node.resolveType())
-      .unwrapOr(nothingType);
+      .unwrapOr(nothingType());
     return new FunctionSymbolType({
       parameterTypes: parameterTypes,
       returnType: returnType,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -135,7 +135,7 @@ export function createRuntimeBindingRuntimeSymbol(
  */
 function createRuntimeBindingStaticSymbol(
     parameters: HookParameter[],
-    returnType: SymbolType = nothingType,
+    returnType: SymbolType = nothingType(),
 ): StaticSymbol {
     const parameterTypes = parameters.map((param) => param.symbolType);
     return new StaticSymbol({
@@ -196,7 +196,7 @@ export function injectRuntimeBindings(
             name: "message",
             symbolType: new CompositeSymbolType({ id: "String" }),
         }],
-        nothingType,
+        nothingType(),
         (params) => {
             const message = params.get("message")!.value as string;
             stdout?.writeLine(message);
@@ -210,7 +210,7 @@ export function injectRuntimeBindings(
             name: "message",
             symbolType: new CompositeSymbolType({ id: "String" }),
         }],
-        nothingType,
+        nothingType(),
         (params) => {
             const message = params.get("message")!.value as string;
             stdout?.writeChunk(message);
@@ -224,7 +224,7 @@ export function injectRuntimeBindings(
             name: "reason",
             symbolType: new CompositeSymbolType({ id: "String" }),
         }],
-        nothingType,
+        nothingType(),
         (params) => {
             const reason = params.get("reason")!.value as string;
             throw new PanicError(reason);

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -67,7 +67,7 @@ export function analyzeStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
     analysisTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
     analysisTable.ignoreRuntimeBindings = false;
-    typeTable.setGlobalFlagOverrides({ readonly: true });
+    typeTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
     typeTable.ignoreRuntimeTypes = false;
     const analysisFindings = stdlibAst.analyze();
     updateEnvironment({ source: "" });
@@ -76,7 +76,7 @@ export function analyzeStdlib(stdlibAst: AST) {
         stdlib: "notset",
     });
     analysisTable.ignoreRuntimeBindings = true;
-    typeTable.setGlobalFlagOverrides({ readonly: "notset" });
+    typeTable.setGlobalFlagOverrides({ readonly: "notset", stdlib: "notset" });
     typeTable.ignoreRuntimeTypes = true;
     if (analysisFindings.errors.length !== 0) {
         throw new InternalError(
@@ -92,12 +92,12 @@ export function analyzeStdlib(stdlibAst: AST) {
 export function injectStdlib(stdlibAst: AST) {
     updateEnvironment({ source: stdlib });
     runtimeTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
-    typeTable.setGlobalFlagOverrides({ readonly: true });
+    typeTable.setGlobalFlagOverrides({ readonly: true, stdlib: true });
     stdlibAst.interpret();
     runtimeTable.setGlobalFlagOverrides({
         readonly: "notset",
         stdlib: "notset",
     });
-    typeTable.setGlobalFlagOverrides({ readonly: "notset" });
+    typeTable.setGlobalFlagOverrides({ readonly: "notset", stdlib: "notset" });
     updateEnvironment({ source: "" });
 }

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -34,6 +34,60 @@ const stdlib = `
         }
     }
 
+    type Result<T, E> {
+        is_ok: Function() -> Boolean
+        get_value: Function(Result<T, E>) -> T
+        get_error: Function(Result<T, E>) -> E
+        map: Function(Result<T, E>, Function(T) -> T) -> Result<T, E>
+    }
+
+    type Ok<T, E> implements Result<T, E> {
+        value: T
+
+        is_ok = function() -> Boolean {
+            return true
+        }
+
+        get_value = function(this: Ok<T, E>) -> T {
+            return this.value
+        }
+
+        get_error = function(this: Ok<T, E>) -> E {
+            panic("get_error called on an Ok object")
+        }
+
+        map = function(
+            this: Ok<T, E>,
+            transform: Function(T) -> T
+        ) -> Result<T, E> {
+            mapped_value = transform(this.value)
+            return Ok<T, E>(mapped_value)
+        }
+    }
+
+    type Error<T, E> implements Result<T, E> {
+        error: E
+
+        is_ok = function() -> Boolean {
+            return false
+        }
+
+        get_value = function(this: Error<T, E>) -> T {
+            panic("get_value called on an Error object")
+        }
+
+        get_error = function(this: Error<T, E>) -> E {
+            return this.error
+        }
+
+        map = function(
+            this: Error<T, E>,
+            transform: Function(T) -> T
+        ) -> Result<T, E> {
+            return this
+        }
+    }
+
     print = function(message: String) {
         runtime_print_newline(message)
     }

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -18,6 +18,33 @@ const stdlib = `
     reverse = function(message: String) -> String {
         return runtime_reverse(message)
     }
+
+    type COption<T> {
+        has_value: Function() -> Boolean,
+        get_value: Function(COption<T>) -> T,
+    }
+
+    type CNothing<T> implements COption<T> {
+        has_value = function() -> Boolean {
+            return false
+        }
+
+        get_value = function(this: CNothing<T>) -> T {
+            panic("get_value called on a Nothing object")
+        }
+    }
+
+    type CSomething<T> implements COption<T> {
+        value: T
+
+        has_value = function() -> Boolean {
+            return true
+        }
+
+        get_value = function(this: CSomething<T>) -> T {
+            return this.value
+        }
+    }
 `;
 
 /**

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -53,7 +53,7 @@ const stdlib = `
         }
 
         get_error = function(this: Ok<T, E>) -> E {
-            panic("get_error called on an Ok object")
+            runtime_panic("get_error called on an Ok object")
         }
 
         map = function(
@@ -73,7 +73,7 @@ const stdlib = `
         }
 
         get_value = function(this: Error<T, E>) -> T {
-            panic("get_value called on an Error object")
+            runtime_panic("get_value called on an Error object")
         }
 
         get_error = function(this: Error<T, E>) -> E {

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -18,7 +18,7 @@ const stdlib = `
         }
 
         get_value = function(this: Nothing<T>) -> T {
-            panic("get_value called on a Nothing object")
+            runtime_panic("get_value called on a Nothing object")
         }
     }
 

--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -7,6 +7,33 @@ import { updateEnvironment } from "./util/environment.ts";
 import { InternalError } from "./util/error.ts";
 
 const stdlib = `
+    type Option<T> {
+        has_value: Function() -> Boolean,
+        get_value: Function(Option<T>) -> T,
+    }
+
+    type Nothing<T> implements Option<T> {
+        has_value = function() -> Boolean {
+            return false
+        }
+
+        get_value = function(this: Nothing<T>) -> T {
+            panic("get_value called on a Nothing object")
+        }
+    }
+
+    type Something<T> implements Option<T> {
+        value: T
+
+        has_value = function() -> Boolean {
+            return true
+        }
+
+        get_value = function(this: Something<T>) -> T {
+            return this.value
+        }
+    }
+
     print = function(message: String) {
         runtime_print_newline(message)
     }
@@ -17,33 +44,6 @@ const stdlib = `
 
     reverse = function(message: String) -> String {
         return runtime_reverse(message)
-    }
-
-    type COption<T> {
-        has_value: Function() -> Boolean,
-        get_value: Function(COption<T>) -> T,
-    }
-
-    type CNothing<T> implements COption<T> {
-        has_value = function() -> Boolean {
-            return false
-        }
-
-        get_value = function(this: CNothing<T>) -> T {
-            panic("get_value called on a Nothing object")
-        }
-    }
-
-    type CSomething<T> implements COption<T> {
-        value: T
-
-        has_value = function() -> Boolean {
-            return true
-        }
-
-        get_value = function(this: CSomething<T>) -> T {
-            return this.value
-        }
     }
 `;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -1049,11 +1049,11 @@ export class TypeTable {
 
     // will be replaced by stdlib implementation in the future
 
-    this.setType(
+    /* this.setType(
       "Nothing",
       new CompositeSymbolType({ id: "Nothing" }),
       { readonly: true },
-    );
+    ); */
 
     /* ~~~ TEMPORARY ~~~ */
   }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1049,11 +1049,16 @@ export class TypeTable {
 
     // will be replaced by stdlib implementation in the future
 
-    /* this.setType(
+    this.setType(
       "Nothing",
-      new CompositeSymbolType({ id: "Nothing" }),
-      { readonly: true },
-    ); */
+      new CompositeSymbolType({
+        id: "Nothing",
+        placeholders: new Map([
+          ["T", new PlaceholderSymbolType({ name: "T" })],
+        ]),
+      }),
+      { readonly: false },
+    );
 
     /* ~~~ TEMPORARY ~~~ */
   }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1053,10 +1053,12 @@ export class TypeTable {
       { readonly: true },
     );
 
-    /* ~~~ TEMPORARY ~~~ */
-
-    // will be replaced by stdlib implementation in the future
-
+    // The `Nothing` is initialized in the stdlib. However, to initialize the
+    // runtime bindings (which happens before the stdlib can be loaded),
+    // the `Nothing` type already needs to be present in the type table.
+    // Therefore, the type is created temporarily and is later overriden
+    // by the `Nothing` type from the stdlib. To allow overriding the type,
+    // the `readonly` flag is set to `false`.
     this.setType(
       "Nothing",
       new CompositeSymbolType({
@@ -1067,8 +1069,6 @@ export class TypeTable {
       }),
       { readonly: false },
     );
-
-    /* ~~~ TEMPORARY ~~~ */
   }
 
   reset() {

--- a/src/type.ts
+++ b/src/type.ts
@@ -874,6 +874,12 @@ type TypeFlags = {
    * Mainly used to protect stdlib contents from being reassigned.
    */
   readonly: boolean;
+  /**
+   * Whether the type is part of the standard library.
+   * Usually, this flag is used in conjunction with the `readonly` flag
+   * to provide a reason as to why a type cannot be reassigned.
+   */
+  stdlib: boolean;
 };
 
 type TypeEntry = TypeFlags & {
@@ -906,6 +912,7 @@ export class TypeTable {
     [K in keyof TypeFlags]: TypeFlags[K] | "notset";
   } = {
     readonly: "notset",
+    stdlib: "notset",
   };
   /**
    * When set to `true`, the table will act as if types stored
@@ -942,7 +949,7 @@ export class TypeTable {
     if (!this.ignoreRuntimeTypes) {
       const runtimeType = this.runtimeTypes.get(name);
       if (runtimeType !== undefined) {
-        return Some([runtimeType, { readonly: true, runtimeBinding: true }]);
+        return Some([runtimeType, { readonly: true, stdlib: false }]);
       }
     }
     const current = this.scopes.at(-1);
@@ -960,7 +967,7 @@ export class TypeTable {
     if (!this.ignoreRuntimeTypes) {
       const runtimeType = this.runtimeTypes.get(name);
       if (runtimeType !== undefined) {
-        return Some([runtimeType, { readonly: true, runtimeBinding: true }]);
+        return Some([runtimeType, { readonly: true, stdlib: false }]);
       }
     }
     for (const currentScope of this.scopes.toReversed()) {
@@ -1003,6 +1010,7 @@ export class TypeTable {
     const entry: TypeEntry = {
       type: symbolType,
       readonly: flags.readonly ?? this.getGlobalFlagOverride("readonly"),
+      stdlib: flags.stdlib ?? this.getGlobalFlagOverride("stdlib"),
     };
     currentScope.types.set(name, entry);
   }

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -1,5 +1,5 @@
 import { CompositeSymbolValue } from "../symbol.ts";
-import { typeTable } from "../type.ts";
+import { SymbolType, typeTable } from "../type.ts";
 import { InternalError } from "./error.ts";
 import { Option } from "./monad/index.ts";
 
@@ -45,15 +45,17 @@ export type WithOptionalAttributes<T> = ConvertOptionals<Attributes<T>>;
 /**
  * The `Nothing` type from the standard library.
  */
-export const nothingType = typeTable
-  .findType("Nothing")
-  .map(([type, _flags]) => type)
-  .unwrapOrThrow(
-    new InternalError(
-      "The type called `Nothing` from the standard library could not be located.",
-      "This type is required for basic language functionality.",
-    ),
-  );
+export function nothingType(): SymbolType {
+  return typeTable
+    .findType("Nothing")
+    .map(([type, _flags]) => type)
+    .unwrapOrThrow(
+      new InternalError(
+        "The type called `Nothing` from the standard library could not be located.",
+        "This type is required for basic language functionality.",
+      ),
+    );
+}
 
 /**
  * An instance of the `Nothing` type from the standard library.


### PR DESCRIPTION
This PR extends the standard library with the `Option` and `Result` types. `Option` is implemented by `Something` and `Nothing` which represent the presence and absence of a value, respectively. `Result`is implemented by `Ok` and `Error` which represent successful and unsuccessful operations.