### PR TITLE
Expose missing type in library

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { FileLike, VirtualTextFile } from "./streams.ts";
 import { Ok, Result } from "./util/monad/index.ts";
 import { Err } from "./util/monad/result.ts";
 
+export { ExecutionEnvironment } from "./execution.ts";
 export type {
   AnalysisFinding,
   AnalysisFindingKind,


### PR DESCRIPTION
This PR explicitly exports the `ExecutionEnvironment` type so it can be imported from the library.