### PR TITLE
Fix static analysis of property access wrapped in a type definition.

### DIFF
--- a/src/features/symbol_expression.ts
+++ b/src/features/symbol_expression.ts
@@ -4,7 +4,7 @@ import { ExecutionEnvironment } from "../execution.ts";
 import { AnalysisError, AnalysisFindings } from "../finding.ts";
 import { TokenKind } from "../lexer.ts";
 import { CompositeSymbolValue, SymbolFlags, SymbolValue } from "../symbol.ts";
-import { CompositeSymbolType, SymbolType } from "../type.ts";
+import { CompositeSymbolType, IgnoreSymbolType, SymbolType } from "../type.ts";
 import { InternalError } from "../util/error.ts";
 import { None } from "../util/monad/index.ts";
 import {
@@ -112,6 +112,9 @@ export class PropertyAccessAstNode implements EvaluableAstNode {
       return findings;
     }
     const parentType = this.parent.resolveType(environment).peel();
+    if (parentType instanceof IgnoreSymbolType) {
+      return findings;
+    }
     if (parentType instanceof CompositeSymbolType) {
       const fieldExists = parentType.fields.has(this.identifierToken.text);
       if (fieldExists) {


### PR DESCRIPTION
When a type is defined, its fields are initially set to `IgnoreSymbolType`. When one of the fields is a function/method, that method may try to access one of these fields. The interpreter will invoke static analysis for that function while the other fields are still set to `IgnoreSymbolType`. When the function includes a property-access (e.g. `this.next.append`), the parent (`this.next`) needs to be checked for being of `IgnoreSymbolType`. If so, the analysis should return without any findings.

Example:
```
type Node {
  append: Function(Node) -> Node
}

type Container implements Node {
  next: Node

  append = function(this: Container) -> Node {
    // this is where the error occurs
    // when static analysis is invoked for this method for the first time,
    // `this.next` is still of `IgnoreSymbolType`, leading to an error.
    this.next.append  
  }
}
```