### PR TITLE
Replace escape sequences in strings

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -16,6 +16,7 @@ export enum TokenKind {
   stringContents,
   stringDelimiter,
   stringInterpolationDelimiter,
+  stringEscapeSequence,
   unspecified,
 }
 
@@ -45,9 +46,9 @@ statements.push(
 stringLiteral.push(
   [true, /^"/g, TokenKind.stringDelimiter, "pop"],
   [true, /^\${/g, TokenKind.stringInterpolationDelimiter, statements],
+  [true, /^\\./g, TokenKind.stringEscapeSequence],
   [true, /^\\"/g, TokenKind.stringContents],
   [true, /^\$/g, TokenKind.stringContents],
-  [true, /^\\\${/g, TokenKind.stringContents],
   [true, /^[^"$\\]+/g, TokenKind.stringContents],
 );
 


### PR DESCRIPTION
This PR addresses the issue where escape sequences would stay in the final string. To accomplish this, the lexer has been adjusted to tokenize escape sequences separately. These escape sequences are processed in a new AST node called `StringEscapeSequenceAstNode` which is responsible for the actual replacement.

Closes #71